### PR TITLE
Baking compatibility with add_compiled

### DIFF
--- a/examples/bakery_examples/pre_compile_compatibility/baked_add_compile.py
+++ b/examples/bakery_examples/pre_compile_compatibility/baked_add_compile.py
@@ -1,0 +1,39 @@
+from qualang_tools import baking
+from qm.qua import *
+from qm.QuantumMachinesManager import QuantumMachinesManager
+from config import config
+
+# Create a first baked waveform, overridable
+# and which will be inserted in the config
+with baking(config, padding_method="right",
+            override=True, update_config=True) as b_template:
+    samples_I = [0.1, 0.1, 0.2, 0.1, 0.2]
+    samples_Q = [0.2, 0.2, 0.3, 0.1, 0.0]
+    b_template.add_Op("Op", "qe1", [samples_I, samples_Q])
+    b_template.play("Op", "qe1")
+
+# Re-open the context manager with either same baking object (b_template) or a new one (b_new) to generate a
+# new waveform
+# Only important thing is to indicate which baking index it shall use to generate the right name to override waveform
+# Note that override parameter and update_config are not relevant anymore (since program is already compiled with a
+# previous config, as we only want to retrieve the waveforms out
+# of this new baking object
+with baking(config, padding_method="right", override=False,
+            update_config=False, baking_index=b_template.get_baking_index()) as b_new:
+    samples_I = [0.3, 0.3, 0.4]
+    samples_Q = [0.0, 0.1, 0.2]
+    b_new.add_Op("Op", "qe1", [samples_I, samples_Q])
+    b_new.play("Op", "qe1")
+
+print(b_template.get_waveforms_dict())
+print(b_new.get_waveforms_dict())
+qmm = QuantumMachinesManager()
+qm = qmm.open_qm(config)
+
+with program() as prog:
+    b_template.run()
+
+pid = qm.queue.compile(prog)
+pjob = qm.queue.add_compiled(prog, overrides={b_new.get_waveforms_dict()})
+job = qm.queue.wait_for_execution(pjob)
+job.results_handles.wait_for_all_values()

--- a/examples/bakery_examples/pre_compile_compatibility/baked_add_compile.py
+++ b/examples/bakery_examples/pre_compile_compatibility/baked_add_compile.py
@@ -5,8 +5,9 @@ from config import config
 
 # Create a first baked waveform, overridable
 # and which will be inserted in the config
-with baking(config, padding_method="right",
-            override=True, update_config=True) as b_template:
+with baking(
+    config, padding_method="right", override=True, update_config=True
+) as b_template:
     samples_I = [0.1, 0.1, 0.2, 0.1, 0.2]
     samples_Q = [0.2, 0.2, 0.3, 0.1, 0.0]
     b_template.add_Op("Op", "qe1", [samples_I, samples_Q])
@@ -18,8 +19,13 @@ with baking(config, padding_method="right",
 # Note that override parameter and update_config are not relevant anymore (since program is already compiled with a
 # previous config, as we only want to retrieve the waveforms out
 # of this new baking object
-with baking(config, padding_method="right", override=False,
-            update_config=False, baking_index=b_template.get_baking_index()) as b_new:
+with baking(
+    config,
+    padding_method="right",
+    override=False,
+    update_config=False,
+    baking_index=b_template.get_baking_index(),
+) as b_new:
     samples_I = [0.3, 0.3, 0.4]
     samples_Q = [0.0, 0.1, 0.2]
     b_new.add_Op("Op", "qe1", [samples_I, samples_Q])

--- a/examples/bakery_examples/pre_compile_compatibility/config.py
+++ b/examples/bakery_examples/pre_compile_compatibility/config.py
@@ -59,7 +59,6 @@ config = {
                 "Y/2": "Y/2Pulse",
                 "Y": "YPulse",
                 "-Y/2": "-Y/2Pulse",
-
             },
         },
         "rr": {

--- a/examples/bakery_examples/pre_compile_compatibility/config.py
+++ b/examples/bakery_examples/pre_compile_compatibility/config.py
@@ -1,0 +1,171 @@
+import numpy as np
+
+pulse_len = 80
+readout_len = 400
+qubit_IF = 50e6
+rr_IF = 50e6
+qubit_LO = 6.345e9
+rr_LO = 4.755e9
+
+
+def gauss(amplitude, mu, sigma, length):
+    t = np.linspace(-length / 2, length / 2, length)
+    gauss_wave = amplitude * np.exp(-((t - mu) ** 2) / (2 * sigma ** 2))
+    return [float(x) for x in gauss_wave]
+
+
+def IQ_imbalance(g, phi):
+    c = np.cos(phi)
+    s = np.sin(phi)
+    N = 1 / ((1 - g ** 2) * (2 * c ** 2 - 1))
+    return [float(N * x) for x in [(1 - g) * c, (1 + g) * s, (1 - g) * s, (1 + g) * c]]
+
+
+gauss_pulse = gauss(0.2, 0, 20, pulse_len)
+
+config = {
+    "version": 1,
+    "controllers": {
+        "con1": {
+            "type": "opx1",
+            "analog_outputs": {
+                1: {"offset": +0.0},  # qe-I
+                2: {"offset": +0.0},  # qe-Q
+                3: {"offset": +0.0},  # rr-I
+                4: {"offset": +0.0},  # rr-Q
+            },
+            "digital_outputs": {
+                1: {},
+            },
+            "analog_inputs": {
+                1: {"offset": +0.0},
+            },
+        }
+    },
+    "elements": {
+        "qe1": {
+            "mixInputs": {
+                "I": ("con1", 1),
+                "Q": ("con1", 2),
+                "lo_frequency": qubit_LO,
+                "mixer": "mixer_qubit",
+            },
+            "intermediate_frequency": qubit_IF,
+            "operations": {
+                "I": "IPulse",
+                "X/2": "X/2Pulse",
+                "X": "XPulse",
+                "-X/2": "-X/2Pulse",
+                "Y/2": "Y/2Pulse",
+                "Y": "YPulse",
+                "-Y/2": "-Y/2Pulse",
+
+            },
+        },
+        "rr": {
+            "mixInputs": {
+                "I": ("con1", 3),
+                "Q": ("con1", 4),
+                "lo_frequency": rr_LO,
+                "mixer": "mixer_RR",
+            },
+            "intermediate_frequency": rr_IF,
+            "operations": {
+                "readout": "readout_pulse",
+            },
+            "outputs": {"out1": ("con1", 1)},
+            "time_of_flight": 28,
+            "smearing": 0,
+        },
+    },
+    "pulses": {
+        "constPulse": {
+            "operation": "control",
+            "length": pulse_len,
+            "waveforms": {"I": "gauss_wf", "Q": "gauss_wf"},
+        },
+        "IPulse": {
+            "operation": "control",
+            "length": pulse_len,
+            "waveforms": {"I": "zero_wf", "Q": "zero_wf"},
+        },
+        "XPulse": {
+            "operation": "control",
+            "length": pulse_len,
+            "waveforms": {"I": "const_wf", "Q": "zero_wf"},
+        },
+        "X/2Pulse": {
+            "operation": "control",
+            "length": pulse_len,
+            "waveforms": {"I": "pi/2_wf", "Q": "zero_wf"},
+        },
+        "-X/2Pulse": {
+            "operation": "control",
+            "length": pulse_len,
+            "waveforms": {"I": "-pi/2_wf", "Q": "zero_wf"},
+        },
+        "YPulse": {
+            "operation": "control",
+            "length": pulse_len,
+            "waveforms": {"I": "zero_wf", "Q": "pi_wf"},
+        },
+        "Y/2Pulse": {
+            "operation": "control",
+            "length": pulse_len,
+            "waveforms": {"I": "zero_wf", "Q": "pi/2_wf"},
+        },
+        "-Y/2Pulse": {
+            "operation": "control",
+            "length": pulse_len,
+            "waveforms": {"I": "zero_wf", "Q": "-pi/2_wf"},
+        },
+        "readout_pulse": {
+            "operation": "measurement",
+            "length": readout_len,
+            "waveforms": {"I": "readout_wf", "Q": "zero_wf"},
+            "integration_weights": {
+                "integW1": "integW1",
+                "integW2": "integW2",
+            },
+            "digital_marker": "ON",
+        },
+    },
+    "waveforms": {
+        "const_wf": {"type": "constant", "sample": 0.2},
+        "gauss_wf": {"type": "arbitrary", "samples": gauss_pulse},
+        "pi_wf": {"type": "arbitrary", "samples": gauss(0.2, 0, 12, pulse_len)},
+        "-pi/2_wf": {"type": "arbitrary", "samples": gauss(-0.1, 0, 12, pulse_len)},
+        "pi/2_wf": {"type": "arbitrary", "samples": gauss(0.1, 0, 12, pulse_len)},
+        "zero_wf": {"type": "constant", "sample": 0.0},
+        "readout_wf": {"type": "constant", "sample": 0.3},
+    },
+    "digital_waveforms": {
+        "ON": {"samples": [(1, 0)]},
+    },
+    "integration_weights": {
+        "integW1": {
+            "cosine": [1.0] * int(readout_len / 4),
+            "sine": [0.0] * int(readout_len / 4),
+        },
+        "integW2": {
+            "cosine": [0.0] * int(readout_len / 4),
+            "sine": [1.0] * int(readout_len / 4),
+        },
+    },
+    "mixers": {
+        "mixer_qubit": [
+            {
+                "intermediate_frequency": qubit_IF,
+                "lo_frequency": qubit_LO,
+                "correction": IQ_imbalance(0.0, 0.0),
+            }
+        ],
+        "mixer_RR": [
+            {
+                "intermediate_frequency": rr_IF,
+                "lo_frequency": rr_LO,
+                "correction": IQ_imbalance(0.0, 0.0),
+            }
+        ],
+    },
+}

--- a/qualang_tools/bakery/bakery.py
+++ b/qualang_tools/bakery/bakery.py
@@ -322,6 +322,21 @@ class Baking:
     def get_waveforms_dict(self):
         return self.override_waveforms_dict
 
+    def delete_baked_Op(self, qe: str):
+        """
+        Delete in the input config of the baking object the associated baked operation and
+        its associated pulse and waveform(s) for the specified quantum element
+        :param qe: quantum element
+        :return:
+        """
+        del self.config["elements"][qe]["operations"][f"baked_Op_{self._ctr}"]
+        del self.config["pulses"][f"{qe}_baked_pulse_{self._ctr}"]
+        if "mixInputs" in self.config["elements"][qe]:
+            del self.config["waveforms"][f"{qe}_baked_wf_I_{self._ctr}"]
+            del self.config["waveforms"][f"{qe}_baked_wf_Q_{self._ctr}"]
+        elif "singleInput" in self.config["elements"][qe]:
+            del self.config["waveforms"][f"{qe}_baked_wf_{self._ctr}"]
+
     def get_Op_name(self, qe: str):
         """
         Get the baked operation issued from the baking object for quantum element qe

--- a/qualang_tools/bakery/bakery.py
+++ b/qualang_tools/bakery/bakery.py
@@ -10,11 +10,11 @@ import copy
 
 
 def baking(
-        config,
-        padding_method="right",
-        override=False,
-        update_config: bool = True,
-        baking_index: int = None,
+    config,
+    padding_method="right",
+    override=False,
+    update_config: bool = True,
+    baking_index: int = None,
 ):
     """
     Opens a context manager to synthesize samples for arbitrary waveforms
@@ -33,12 +33,12 @@ def baking(
 
 class Baking:
     def __init__(
-            self,
-            config,
-            padding_method: str = "right",
-            override: bool = False,
-            update_config: bool = True,
-            baking_index: int = None
+        self,
+        config,
+        padding_method: str = "right",
+        override: bool = False,
+        update_config: bool = True,
+        baking_index: int = None,
     ):
         self._config = config
         self.update_config = update_config
@@ -158,26 +158,24 @@ class Baking:
             # in original config file
 
             if (
-                    self._qe_dict[qe]["time"] > 0
+                self._qe_dict[qe]["time"] > 0
             ):  # Check if a sample was added to the quantum element
                 # otherwise we do not add any Op
                 self._qe_set.add(qe)
                 if self.length_constraint is not None:
-                    assert (
-                            self._qe_dict[qe]["time"] < self.length_constraint
-                    ), f"Provided length constraint (={self.length_constraint}) " \
-                       f"smaller than actual baked samples length ({self._qe_dict[qe]['time']})"
-                    wait_duration += (
-                            self.length_constraint - self._qe_dict[qe]["time"]
+                    assert self._qe_dict[qe]["time"] < self.length_constraint, (
+                        f"Provided length constraint (={self.length_constraint}) "
+                        f"smaller than actual baked samples length ({self._qe_dict[qe]['time']})"
                     )
+                    wait_duration += self.length_constraint - self._qe_dict[qe]["time"]
                     self.wait(self.length_constraint - self._qe_dict[qe]["time"])
                 if (
-                        self._qe_dict[qe]["time"] < 16
+                    self._qe_dict[qe]["time"] < 16
                 ):  # Sample length must be at least 16 ns long
                     wait_duration += 16 - self._qe_dict[qe]["time"]
                     self.wait(16 - self._qe_dict[qe]["time"], qe)
                 if (
-                        not self._qe_dict[qe]["time"] % 4 == 0
+                    not self._qe_dict[qe]["time"] % 4 == 0
                 ):  # Sample length must be a multiple of 4
                     wait_duration += 4 - self._qe_dict[qe]["time"] % 4
                     self.wait(4 - self._qe_dict[qe]["time"] % 4, qe)
@@ -195,53 +193,53 @@ class Baking:
                 elif self._padding_method == "left":
                     if "mixInputs" in elements[qe]:
                         qe_samples["I"] = (
-                                qe_samples["I"][end_samples:]
-                                + qe_samples["I"][0:end_samples]
+                            qe_samples["I"][end_samples:]
+                            + qe_samples["I"][0:end_samples]
                         )
                         qe_samples["Q"] = (
-                                qe_samples["Q"][end_samples:]
-                                + qe_samples["Q"][0:end_samples]
+                            qe_samples["Q"][end_samples:]
+                            + qe_samples["Q"][0:end_samples]
                         )
                     elif "singleInput" in elements[qe]:
                         qe_samples["single"] = (
-                                qe_samples["single"][end_samples:]
-                                + qe_samples["single"][0:end_samples]
+                            qe_samples["single"][end_samples:]
+                            + qe_samples["single"][0:end_samples]
                         )
 
                 elif self._padding_method == "symmetric_l":
                     if "mixInputs" in elements[qe]:
                         qe_samples["I"] = (
-                                qe_samples["I"][end_samples + wait_duration // 2:]
-                                + qe_samples["I"][0: end_samples + wait_duration // 2]
+                            qe_samples["I"][end_samples + wait_duration // 2 :]
+                            + qe_samples["I"][0 : end_samples + wait_duration // 2]
                         )
 
                         qe_samples["Q"] = (
-                                qe_samples["Q"][end_samples + wait_duration // 2:]
-                                + qe_samples["Q"][0: end_samples + wait_duration // 2]
+                            qe_samples["Q"][end_samples + wait_duration // 2 :]
+                            + qe_samples["Q"][0 : end_samples + wait_duration // 2]
                         )
 
                     elif "singleInput" in elements[qe]:
                         qe_samples["single"] = (
-                                qe_samples["single"][end_samples + wait_duration // 2:]
-                                + qe_samples["single"][0: end_samples + wait_duration // 2]
+                            qe_samples["single"][end_samples + wait_duration // 2 :]
+                            + qe_samples["single"][0 : end_samples + wait_duration // 2]
                         )
 
                 elif self._padding_method == "symmetric_r":
                     if "mixInputs" in elements[qe]:
                         qe_samples["I"] = (
-                                qe_samples["I"][end_samples + wait_duration // 2 + 1:]
-                                + qe_samples["I"][0: end_samples + wait_duration // 2 + 1]
+                            qe_samples["I"][end_samples + wait_duration // 2 + 1 :]
+                            + qe_samples["I"][0 : end_samples + wait_duration // 2 + 1]
                         )
                         qe_samples["Q"] = (
-                                qe_samples["Q"][end_samples + wait_duration // 2 + 1:]
-                                + qe_samples["Q"][0: end_samples + wait_duration // 2 + 1]
+                            qe_samples["Q"][end_samples + wait_duration // 2 + 1 :]
+                            + qe_samples["Q"][0 : end_samples + wait_duration // 2 + 1]
                         )
                     elif "singleInput" in elements[qe]:
                         qe_samples["single"] = (
-                                qe_samples["single"][end_samples + wait_duration // 2 + 1:]
-                                + qe_samples["single"][
-                                  0: end_samples + wait_duration // 2 + 1
-                                  ]
+                            qe_samples["single"][end_samples + wait_duration // 2 + 1 :]
+                            + qe_samples["single"][
+                                0 : end_samples + wait_duration // 2 + 1
+                            ]
                         )
 
                 if self.update_config:
@@ -271,8 +269,8 @@ class Baking:
                 wf = self._local_config["pulses"][pulse]["waveforms"]["single"]
                 if self._local_config["waveforms"][wf]["type"] == "constant":
                     return [
-                               self._local_config["waveforms"][wf]["sample"]
-                           ] * self._local_config["pulses"][pulse]["length"]
+                        self._local_config["waveforms"][wf]["sample"]
+                    ] * self._local_config["pulses"][pulse]["length"]
                 else:
                     return list(self._local_config["waveforms"][wf]["samples"])
             elif "I" in self._local_config["pulses"][pulse]["waveforms"]:
@@ -280,14 +278,14 @@ class Baking:
                 wf_Q = self._local_config["pulses"][pulse]["waveforms"]["Q"]
                 if self._local_config["waveforms"][wf_I]["type"] == "constant":
                     samples_I = [
-                                    self._local_config["waveforms"][wf_I]["sample"]
-                                ] * self._local_config["pulses"][pulse]["length"]
+                        self._local_config["waveforms"][wf_I]["sample"]
+                    ] * self._local_config["pulses"][pulse]["length"]
                 else:
                     samples_I = list(self._local_config["waveforms"][wf_I]["samples"])
                 if self._local_config["waveforms"][wf_Q]["type"] == "constant":
                     samples_Q = [
-                                    self._local_config["waveforms"][wf_Q]["sample"]
-                                ] * self._local_config["pulses"][pulse]["length"]
+                        self._local_config["waveforms"][wf_Q]["sample"]
+                    ] * self._local_config["pulses"][pulse]["length"]
                 else:
                     samples_Q = list(self._local_config["waveforms"][wf_Q]["samples"])
                 return [samples_I, samples_Q]
@@ -356,11 +354,11 @@ class Baking:
                 )
 
     def add_Op(
-            self,
-            name: str,
-            qe: str,
-            samples: Union[list, list[list]],
-            digital_marker: str = None,
+        self,
+        name: str,
+        qe: str,
+        samples: Union[list, list[list]],
+        digital_marker: str = None,
     ):
         """
         Adds in the configuration file a pulse element.
@@ -482,12 +480,12 @@ class Baking:
                             I2[i] = amp[0] * I[i] + amp[1] * Q[i]
                             Q2[i] = amp[2] * I[i] + amp[3] * Q[i]
                         I3[i] = (
-                                np.cos(freq * i * 1e-9 + phi) * I2[i]
-                                - np.sin(freq * i * 1e-9 + phi) * Q2[i]
+                            np.cos(freq * i * 1e-9 + phi) * I2[i]
+                            - np.sin(freq * i * 1e-9 + phi) * Q2[i]
                         )
                         Q3[i] = (
-                                np.sin(freq * i * 1e-9 + phi) * I2[i]
-                                + np.cos(freq * i * 1e-9 + phi) * Q2[i]
+                            np.sin(freq * i * 1e-9 + phi) * I2[i]
+                            + np.cos(freq * i * 1e-9 + phi) * Q2[i]
                         )
 
                         self._samples_dict[qe]["I"].append(I3[i])
@@ -579,16 +577,16 @@ class Baking:
                                 Q2[i] = amp[2] * I[i] + amp[3] * Q[i]
                         if t + i < len(self._samples_dict[qe]["I"]):
                             I3[i] = (
-                                    np.cos(freq[t + i] * (t + i) * 1e-9 + phi[t + i])
-                                    * I2[i]
-                                    - np.sin(freq[t + i] * (t + i) * 1e-9 + phi[t + i])
-                                    * Q2[i]
+                                np.cos(freq[t + i] * (t + i) * 1e-9 + phi[t + i])
+                                * I2[i]
+                                - np.sin(freq[t + i] * (t + i) * 1e-9 + phi[t + i])
+                                * Q2[i]
                             )
                             Q3[i] = (
-                                    np.sin(freq[t + i] * (t + i) * 1e-9 + phi[t + i])
-                                    * I2[i]
-                                    + np.cos(freq[t + i] * (t + i) * 1e-9 + phi[t + i])
-                                    * Q2[i]
+                                np.sin(freq[t + i] * (t + i) * 1e-9 + phi[t + i])
+                                * I2[i]
+                                + np.cos(freq[t + i] * (t + i) * 1e-9 + phi[t + i])
+                                * Q2[i]
                             )
 
                             self._samples_dict[qe]["I"][t + i] += I3[i]
@@ -597,12 +595,12 @@ class Baking:
                             phi = self._qe_dict[qe]["phase"]
                             freq = self._qe_dict[qe]["freq"]
                             I3[i] = (
-                                    np.cos(freq * i * 1e-9 + phi) * I2[i]
-                                    - np.sin(freq * i * 1e-9 + phi) * Q2[i]
+                                np.cos(freq * i * 1e-9 + phi) * I2[i]
+                                - np.sin(freq * i * 1e-9 + phi) * Q2[i]
                             )
                             Q3[i] = (
-                                    np.sin(freq * i * 1e-9 + phi) * I2[i]
-                                    + np.cos(freq * i * 1e-9 + phi) * Q2[i]
+                                np.sin(freq * i * 1e-9 + phi) * I2[i]
+                                + np.cos(freq * i * 1e-9 + phi) * Q2[i]
                             )
 
                             self._samples_dict[qe]["I"].append(I3[i])
@@ -623,7 +621,7 @@ class Baking:
                             phi = self._qe_dict[qe]["phase_track"][t + i]
                             freq = self._qe_dict[qe]["freq_track"][t + i]
                             self._samples_dict[qe]["single"][t + i] += (
-                                    amp * np.cos(freq * (t + i) * 1e-9 + phi) * samples[i]
+                                amp * np.cos(freq * (t + i) * 1e-9 + phi) * samples[i]
                             )
                         else:
                             phi = self._qe_dict[qe]["phase"]
@@ -712,11 +710,11 @@ class Baking:
                 if qe in self._samples_dict.keys():
 
                     self._qe_dict[qe]["phase_track"] += [
-                                                            self._qe_dict[qe]["phase"]
-                                                        ] * duration
+                        self._qe_dict[qe]["phase"]
+                    ] * duration
                     self._qe_dict[qe]["freq_track"] += [
-                                                           self._qe_dict[qe]["freq"]
-                                                       ] * duration
+                        self._qe_dict[qe]["freq"]
+                    ] * duration
                     if "mixInputs" in self._local_config["elements"][qe].keys():
                         self._samples_dict[qe]["I"] += [0] * duration
                         self._samples_dict[qe]["Q"] += [0] * duration
@@ -816,7 +814,7 @@ class Baking:
         if baking_index is not None:
             for pulse in self._local_config["pulses"]:
                 if pulse.find(f"baked_pulse_{baking_index}") != -1:
-                    return self._local_config["pulses"][pulse]['length']
+                    return self._local_config["pulses"][pulse]["length"]
         else:
             return None
 


### PR DESCRIPTION
This PR proposes a new way of using the baking which is from now on not only a tool for updating a config file prior to launching a QUA program, but can be used as simple waveform creator which can be retrieved to be inserted anywhere. The typical use case for this is to generate new baked waveforms that can be used to override older waveforms when using a pre_compile feature, allowing a time reduction of the execution of a new program with different waveforms.
The new method b.get_waveforms_dict() allows the retrieval of those overridable waveforms in a format that can be used directly as an argument of the overrides parameter in the add_compiled method. 

To realise this, there are now more parameters to be fed at the generation of a baking object : 
- Override: boolean indicating if we’d like to set in the config the boolean ‘is_overridable’ to True (for all baked waveforms per baking object, i.e for all quantum elements involved in it)
- update_config: boolean indicating if we are willing to update the input config with the baked samples created within the context manager when exiting it
- baking_index : integer corresponding to the number of another baking object which has updated the config priorly, such that we can retrieve the length of the corresponding baked waveform and put it as length constraint for the new waveform to be generated. This is done to ensure that there will be matching lengths between overridden waveforms when using add_compiled function with newly baked samples.
