### PR TITLE
set workflows for pre-release and released

### DIFF
--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -1,0 +1,27 @@
+name: pre-released
+on:
+  workflow_dispatch:
+  release:
+    types: [prereleased]
+
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - uses: Gr1N/setup-poetry@v4
+      - name: Build package
+        run: |
+          export RELEASE_VERSION="${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          poetry version ${RELEASE_VERSION}
+          poetry build
+      - name: Upload assets
+        uses: qm-devops/qm-upload-release-assets@v1
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          path: |
+            ./dist/*.tar.gz
+            ./dist/*.whl

--- a/.github/workflows/on-released.yml
+++ b/.github/workflows/on-released.yml
@@ -1,8 +1,8 @@
-name: release-version
+name: released
 on:
   workflow_dispatch:
   release:
-    types: [created]
+    types: [released]
 
 jobs:
   publish:
@@ -18,6 +18,10 @@ jobs:
           export RELEASE_VERSION="${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
           poetry version ${RELEASE_VERSION}
           poetry build
+      - name: Update pypi
+        run: |
+          pip install twine
+          twine upload -q -u ${{secrets.PIPY_TOKEN_USER}} -p ${{secrets.PIPY_TOKEN_PWD}} dist/*
       - name: Upload assets
         uses: qm-devops/qm-upload-release-assets@v1
         with:


### PR DESCRIPTION
Will deploy to pypi in case of publish release with no pre-release checkbox
In case pre-release checkbox is on then build and upload as github job asset