### PR TITLE
Added digital waveform handling + new tests

### DIFF
--- a/qualang_tools/bakery/bakery.py
+++ b/qualang_tools/bakery/bakery.py
@@ -3,7 +3,7 @@ Author: Arthur Strauss - Quantum Machines
 Created: 23/02/2021
 """
 
-from typing import List, Union
+from typing import List, Union, Tuple
 import numpy as np
 from qm import qua
 import copy
@@ -426,7 +426,7 @@ class Baking:
         else:
             return self.get_current_length(qe)
 
-    def add_digital_waveform(self, name: str, digital_samples: list):
+    def add_digital_waveform(self, name: str, digital_samples: List[Tuple]):
         """
         Adds a digital waveform to be attached to a baked operation created using the add_Op method
         :param name: name of the digital waveform
@@ -442,7 +442,7 @@ class Baking:
         self,
         name: str,
         qe: str,
-        samples: Union[list, list[list]],
+        samples: Union[List[float], List[List]],
         digital_marker: str = None,
     ):
         """
@@ -520,7 +520,7 @@ class Baking:
         self._local_config["waveforms"].update(waveform)
         self._local_config["elements"][qe]["operations"].update(Op)
 
-    def play(self, Op: str, qe: str, amp: Union[float, tuple] = 1.0) -> None:
+    def play(self, Op: str, qe: str, amp: Union[float, Tuple] = 1.0) -> None:
         """
         Add a pulse to the baked sequence
         :param Op: operation to play to quantum element
@@ -536,6 +536,7 @@ class Baking:
                 phi = self._qe_dict[qe]["phase"]
 
                 if "mixInputs" in self._local_config["elements"][qe]:
+                    assert isinstance(samples, list)
                     assert (
                         len(samples) == 2
                     ), f"{qe} is a mixInput element, two lists should be provided"
@@ -609,7 +610,7 @@ class Baking:
                 f'Op:"{Op}" does not exist in configuration and not manually added (use add_pulse)'
             )
 
-    def play_at(self, Op: str, qe: str, t: int, amp: Union[float, tuple] = 1.0) -> None:
+    def play_at(self, Op: str, qe: str, t: int, amp: Union[float, Tuple] = 1.0) -> None:
         """
         Add a waveform to the sequence at the specified time index.
         If indicated time is higher than the pulse duration for the specified quantum element,
@@ -640,6 +641,7 @@ class Baking:
                 samples = self._get_samples(pulse)
                 new_samples = 0
                 if "mixInputs" in self._local_config["elements"][qe]:
+                    assert isinstance(samples, list)
                     assert (
                         len(samples) == 2
                     ), f"{qe} is a mixInput element, two lists should be provided"
@@ -854,7 +856,7 @@ class Baking:
         else:
             alignment(qe_set)
 
-    def run(self, amp_array=None, trunc_array=None) -> None:
+    def run(self, amp_array: List[Tuple] = None, trunc_array: List[Tuple] = None) -> None:
         """
         Plays the baked waveform
         This method must be used within a QUA program

--- a/qualang_tools/bakery/bakery.py
+++ b/qualang_tools/bakery/bakery.py
@@ -45,7 +45,11 @@ class Baking:
             self.update_config = True
         self._padding_method = padding_method
         self._local_config = copy.deepcopy(config)
-        self._samples_dict, self._qe_dict, self._digital_samples_dict = self._init_dict()
+        (
+            self._samples_dict,
+            self._qe_dict,
+            self._digital_samples_dict,
+        ) = self._init_dict()
         self._ctr = self._find_baking_index(baking_index)  # unique name counter
         self._qe_set = set()
         self.override = override
@@ -54,7 +58,11 @@ class Baking:
         self._out = True
 
     def __enter__(self):
-        self._samples_dict, self._qe_dict, self._digital_samples_dict = self._init_dict()
+        (
+            self._samples_dict,
+            self._qe_dict,
+            self._digital_samples_dict,
+        ) = self._init_dict()
         self._out = False
         return self
 
@@ -150,13 +158,18 @@ class Baking:
                 "is_overridable": self.override,
             }
         if len(self._digital_samples_dict[qe]) != 0:
-            self._config["pulses"][f"{qe}_baked_pulse_{self._ctr}"]["digital_marker"] = f"{qe}_baked_digital_wf_{self._ctr}"
+            self._config["pulses"][f"{qe}_baked_pulse_{self._ctr}"][
+                "digital_marker"
+            ] = f"{qe}_baked_digital_wf_{self._ctr}"
             if "digital_waveforms" in self._config:
-                self._config["digital_waveforms"][f"{qe}_baked_digital_wf_{self._ctr}"] = {"samples": self._digital_samples_dict[qe]}
+                self._config["digital_waveforms"][
+                    f"{qe}_baked_digital_wf_{self._ctr}"
+                ] = {"samples": self._digital_samples_dict[qe]}
             else:
                 self._config["digital_waveforms"] = {}
-                self._config["digital_waveforms"][f"{qe}_baked_digital_wf_{self._ctr}"] = {
-                    "samples": self._digital_samples_dict[qe]}
+                self._config["digital_waveforms"][
+                    f"{qe}_baked_digital_wf_{self._ctr}"
+                ] = {"samples": self._digital_samples_dict[qe]}
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         """
@@ -580,8 +593,12 @@ class Baking:
                     self._update_qe_time(qe, len(samples))
                 # Update of digital waveform
                 if "digital_marker" in self._local_config["pulses"][pulse]:
-                    digital_marker = self._local_config["pulses"][pulse]["digital_marker"]
-                    digital_waveform = self._local_config["digital_waveforms"][digital_marker]["samples"]
+                    digital_marker = self._local_config["pulses"][pulse][
+                        "digital_marker"
+                    ]
+                    digital_waveform = self._local_config["digital_waveforms"][
+                        digital_marker
+                    ]["samples"]
                     self._digital_samples_dict[qe] += digital_waveform
             else:
                 self.play_at(Op, qe, self._qe_dict[qe]["time_track"], amp)

--- a/qualang_tools/bakery/bakery.py
+++ b/qualang_tools/bakery/bakery.py
@@ -442,7 +442,7 @@ class Baking:
         self,
         name: str,
         qe: str,
-        samples: Union[List[float], List[List]],
+        samples: Union[List[float], List[List[float]]],
         digital_marker: str = None,
     ):
         """
@@ -520,7 +520,7 @@ class Baking:
         self._local_config["waveforms"].update(waveform)
         self._local_config["elements"][qe]["operations"].update(Op)
 
-    def play(self, Op: str, qe: str, amp: Union[float, Tuple] = 1.0) -> None:
+    def play(self, Op: str, qe: str, amp: Union[float, Tuple[float]] = 1.0) -> None:
         """
         Add a pulse to the baked sequence
         :param Op: operation to play to quantum element
@@ -610,7 +610,9 @@ class Baking:
                 f'Op:"{Op}" does not exist in configuration and not manually added (use add_pulse)'
             )
 
-    def play_at(self, Op: str, qe: str, t: int, amp: Union[float, Tuple] = 1.0) -> None:
+    def play_at(
+        self, Op: str, qe: str, t: int, amp: Union[float, Tuple[float]] = 1.0
+    ) -> None:
         """
         Add a waveform to the sequence at the specified time index.
         If indicated time is higher than the pulse duration for the specified quantum element,

--- a/qualang_tools/bakery/bakery.py
+++ b/qualang_tools/bakery/bakery.py
@@ -856,7 +856,9 @@ class Baking:
         else:
             alignment(qe_set)
 
-    def run(self, amp_array: List[Tuple] = None, trunc_array: List[Tuple] = None) -> None:
+    def run(
+        self, amp_array: List[Tuple] = None, trunc_array: List[Tuple] = None
+    ) -> None:
         """
         Plays the baked waveform
         This method must be used within a QUA program

--- a/qualang_tools/tests/test_bakery.py
+++ b/qualang_tools/tests/test_bakery.py
@@ -34,14 +34,18 @@ def config():
                     2: {"offset": +0.0},
                     3: {"offset": +0.0},
                 },
-                "digital_outputs": {1: {}, 2: {}}
+                "digital_outputs": {1: {}, 2: {}},
             }
         },
         "elements": {
             "qe1": {
                 "singleInput": {"port": ("con1", 1)},
                 "intermediate_frequency": 0,
-                "operations": {"playOp": "constPulse", "a_pulse": "arb_pulse1", "playOp2": "constPulse2"},
+                "operations": {
+                    "playOp": "constPulse",
+                    "a_pulse": "arb_pulse1",
+                    "playOp2": "constPulse2",
+                },
                 "digitalInputs": {
                     "digital_input1": {
                         "port": ("con1", 1),
@@ -71,7 +75,7 @@ def config():
                 "operation": "control",
                 "length": 1000,  # in ns
                 "waveforms": {"single": "const_wf"},
-                "digital_marker": "ON"
+                "digital_marker": "ON",
             },
             "arb_pulse1": {
                 "operation": "control",
@@ -302,7 +306,12 @@ def test_add_digital_wf(config):
     print(cfg["pulses"]["qe1_baked_pulse_0"])
     print(cfg["waveforms"]["qe1_baked_wf_0"])
     print(cfg["digital_waveforms"])
-    assert cfg["digital_waveforms"]["qe1_baked_digital_wf_0"]["samples"] == [(1, 0), (0, 25), (1, 13), (0, 12)]
+    assert cfg["digital_waveforms"]["qe1_baked_digital_wf_0"]["samples"] == [
+        (1, 0),
+        (0, 25),
+        (1, 13),
+        (0, 12),
+    ]
 
 
 def test_play_baked_with_existing_digital_wf(config):
@@ -315,5 +324,3 @@ def test_play_baked_with_existing_digital_wf(config):
     job = simulate_program_and_return(cfg, prog)
     samples = job.get_simulated_samples()
     assert len(samples.con1.digital["1"] > 0)
-
-


### PR DESCRIPTION
Digital waveform edition is now available within the baking using the add_digital_Op method. One can also add existing digital waveforms in the config by simply playing the pulse associated to it with a b.play command.
Note that handling of digital waveform is only taken care of with the usual b.play command and not b.play_at()