### PR TITLE
Docstrings update + generalization of ways to retrieve length of baked pulses

### DIFF
--- a/qualang_tools/bakery/bakery.py
+++ b/qualang_tools/bakery/bakery.py
@@ -425,34 +425,44 @@ class Baking:
         else:
             return f"baked_Op_{self._ctr}"
 
-    def get_Op_length(self, qe: str) -> int:
+    def get_Op_length(self, qe: Optional[str] = None) -> int:
         """
         Retrieve the length of the finalized baked waveform associated to quantum element qe (outside the baking)
 
-        :param qe: quantum element
-        :returns: Length of baked operation associated to element qe
+        :param qe: target quantum element, if None is provided, then length of the longest baked waveform
+            associated to baking object is returned
+        :returns: Length of baked operation associated to element qe (or maximum length if None is provided)
 
         """
-        if self.update_config:
-            if not (qe in self._qe_set):
-                raise KeyError(
-                    f"{qe} is not in the set of quantum elements of the baking object "
-                )
-            else:
-                if "mixInputs" in self._config["elements"][qe]:
-                    return len(
-                        self._config["waveforms"][f"{qe}_baked_wf_I_{self._ctr}"][
-                            "samples"
-                        ]
+        if qe is not None:
+            if self.update_config and self._out:
+                if not (qe in self._qe_set):
+                    raise KeyError(
+                        f"{qe} is not in the set of quantum elements of the baking object "
                     )
                 else:
-                    return len(
-                        self._config["waveforms"][f"{qe}_baked_wf_{self._ctr}"][
-                            "samples"
-                        ]
-                    )
+                    if "mixInputs" in self._config["elements"][qe]:
+                        return len(
+                            self._config["waveforms"][f"{qe}_baked_wf_I_{self._ctr}"][
+                                "samples"
+                            ]
+                        )
+                    else:
+                        return len(
+                            self._config["waveforms"][f"{qe}_baked_wf_{self._ctr}"][
+                                "samples"
+                            ]
+                        )
+            else:
+                return self.get_current_length(qe)
+
         else:
-            return self.get_current_length(qe)
+            max_length = 0
+            for qe in self._qe_dict:
+                length = self.get_Op_length(qe)
+                if length > max_length:
+                    max_length = length
+            return max_length
 
     def add_digital_waveform(self, name: str, digital_samples: List[Tuple]) -> None:
         """

--- a/qualang_tools/bakery/bakery.py
+++ b/qualang_tools/bakery/bakery.py
@@ -329,7 +329,7 @@ class Baking:
         """
         Retrieve within the baking the current length of the waveform being created (within the baking)
 
-        :param qe quantum element
+        :param qe: quantum element
         """
         if "mixInputs" in self._local_config["elements"][qe]:
             return len(self._samples_dict[qe]["I"])
@@ -353,10 +353,12 @@ class Baking:
 
     def delete_baked_Op(self, *qe_set: str):
         """
-        Delete in the input config of the baking object the associated baked operation and
-        its associated pulse and waveform(s) for the specified quantum element
-        :param qe: tuple of selected quantum elements, if no element is provided, operations are deleted for every element
-        involved within the baking object
+        Delete from config baked operation and its associated pulse and waveform(s) for
+        specified quantum_elements
+
+        :param qe_set:
+            tuple of selected quantum elements, if no element is provided,
+            all baked operations are deleted for every element (associated to baking object)
         """
 
         def remove_Op(q):
@@ -404,7 +406,8 @@ class Baking:
     def get_Op_name(self, qe: str):
         """
         Get the baked operation issued from the baking object for quantum element qe
-        :param qe: quantum element for which the baked operation is intended to be played on
+
+        :param qe: quantum element carrying the baked operation
         """
         if not (qe in self._qe_set):
             raise KeyError(
@@ -416,6 +419,7 @@ class Baking:
     def get_Op_length(self, qe: str):
         """
         Retrieve the length of the finalized baked waveform associated to quantum element qe (outside the baking)
+
         :param qe: quantum element
         """
         if self.update_config:
@@ -442,6 +446,7 @@ class Baking:
     def add_digital_waveform(self, name: str, digital_samples: List[Tuple]):
         """
         Adds a digital waveform to be attached to a baked operation created using the add_Op method
+
         :param name: name of the digital waveform
         :param digital_samples: samples used to generate digital_waveform
         """
@@ -460,6 +465,7 @@ class Baking:
     ):
         """
         Adds an operation playable within the baking context manager.
+
         :param name: name of the Operation to be added for the quantum element (to be used only within the context manager)
         :param qe: targeted quantum element
         :param  samples: arbitrary waveforms to be inserted into pulse definition
@@ -536,10 +542,12 @@ class Baking:
     def play(self, Op: str, qe: str, amp: Union[float, Tuple[float]] = 1.0) -> None:
         """
         Add a pulse to the baked sequence
+
         :param Op: operation to play to quantum element
         :param qe: targeted quantum element
-        :param amp: amplitude of the pulse, can be either a float or a tuple of 4 variables (similar to amp(a) or amp(v00, v01, v10, v11) in QUA)
-        :return:
+        :param amp:
+            amplitude of the pulse, can be either a float or a tuple of 4 variables
+            (similar to amp(a) or amp(v00, v01, v10, v11) in QUA)
         """
         try:
             if self._qe_dict[qe]["time_track"] == 0:
@@ -628,16 +636,16 @@ class Baking:
     ) -> None:
         """
         Add a waveform to the sequence at the specified time index.
-        If indicated time is higher than the pulse duration for the specified quantum element,
-        a wait command followed by the given waveform at indicated time (in ns) occurs.
+        If t is higher than pulse duration for the specified quantum element,
+        a wait command followed by the given waveform at indicated time (in ns) is played.
         Otherwise, waveform is added (addition of samples) to the pre-existing sequence.
         Finally, providing a negative index starts adding the sample with a prior negative wait of t
         Note that the phase played for the newly formed sample is the one that was set before adding the new waveform
+
         :param Op: operation to play to quantum element
         :param qe: targeted quantum element
         :param t: Time tag in ns where the pulse should be added
         :param amp: amplitude of the pulse, can be either a float or a tuple of 4 variables (similar to amp(a) or amp(v00, v01, v10, v11) in QUA)
-        :return:
         """
         if type(t) != int:
             if type(t) == float:
@@ -755,8 +763,10 @@ class Baking:
     def frame_rotation(self, angle: float, qe: str):
         """
         Shift the phase of the oscillator associated with a quantum element by the given angle.
-        This is typically used for virtual z-rotations. Frame rotation done within the baking sticks to the rest of the
+        This is typically used for virtual z-rotations.
+        Frame rotation done within the baking sticks to the rest of the
         QUA program after its execution.
+
         :param angle: phase parameter
         :param qe: quantum element
         """
@@ -767,6 +777,7 @@ class Baking:
         """
         Shift the phase of the oscillator associated with a quantum element by the given angle.
         This is typically used for virtual z-rotations. This performs a frame rotation of 2*π*angle
+
         :param angle: phase parameter
         :param qe: quantum element
         """
@@ -775,15 +786,17 @@ class Baking:
 
     def set_detuning(self, qe: str, freq: int):
         """Update frequency by adding detuning to original IF set in the config.
-        Unlike frame rotation, the detuning will only affect the baked operation and will not stick in the element
-        :param qe quantum element
-        :param freq frequency of the detuning (in Hz)
+        Unlike frame rotation, the detuning will only affect the baked operation and will not stick to the element
+
+        :param qe: quantum element
+        :param freq: frequency of the detuning (in Hz)
         """
         self._qe_dict[qe]["freq"] = freq
 
     def reset_frame(self, *qe_set: str):
         """
         Used to reset all of the frame updated made up to this statement.
+
         :param qe_set: Set[str] of quantum elements
         """
         for qe in qe_set:
@@ -792,6 +805,7 @@ class Baking:
     def ramp(self, amp: float, duration: int, qe: str):
         """
         Analog of ramp function in QUA
+
         :param amp: slope
         :param duration: duration of ramping
         :param qe: quantum element
@@ -848,8 +862,8 @@ class Baking:
         All of the quantum elements referenced in *elements will wait for all
         the others to finish their currently running statement.
 
-        :param qe_set : set of quantum elements to be aligned altogether, if no element is passed, alignment is done
-        all elements within the baking
+        :param qe_set: set of quantum elements to be aligned altogether, if no element is passed, alignment is done
+            for all elements within the baking
         """
 
         def alignment(qe_set2):
@@ -877,10 +891,10 @@ class Baking:
         """
         Plays the baked waveform
         This method must be used within a QUA program
-        :param amp_array list of tuples for amplitudes (e.g [(qe1, amp1), (qe2, amp2)] ), each amplitude must be a scalar
-        :param trunc_array list of tuples for truncations (e.g [(qe1, amp1), (qe2, amp2)] ), each truncation must be a
-         int or QUA int
-        :return None
+
+        :param amp_array: list of tuples for amplitudes (e.g [(qe1, amp1), (qe2, amp2)] ), each amplitude must be a scalar
+        :param trunc_array: list of tuples for truncations (e.g [(qe1, amp1), (qe2, amp2)] ), each truncation must be a
+            int or QUA int
         """
 
         qe_set = self.get_qe_set()
@@ -946,6 +960,7 @@ def deterministic_run(baking_list, j):
     """
     Generates a QUA macro for a binary tree ensuring a synchronized play of operations
     listed in the various baking objects
+    
     :param baking_list: Python list of Baking objects
     :param j: QUA int
     """

--- a/qualang_tools/bakery/bakery.py
+++ b/qualang_tools/bakery/bakery.py
@@ -463,9 +463,10 @@ class Baking:
         else:
             max_length = 0
             for qe in self._qe_dict:
-                length = self.get_Op_length(qe)
-                if length > max_length:
-                    max_length = length
+                if self._qe_dict[qe]["time"] > 0:
+                    length = self.get_Op_length(qe)
+                    if length > max_length:
+                        max_length = length
             return max_length
 
     def add_digital_waveform(self, name: str, digital_samples: List[Tuple]) -> None:

--- a/qualang_tools/bakery/bakery.py
+++ b/qualang_tools/bakery/bakery.py
@@ -365,12 +365,12 @@ class Baking:
 
     def delete_baked_Op(self, *qe_set: str) -> None:
         """
-        Delete from config baked operation and its associated pulse and waveform(s) for
+        Delete from the config the baked operation and its associated pulse and waveform(s) for the
         specified quantum_elements
 
         :param qe_set:
-            tuple of selected quantum elements, if no element is provided,
-            all baked operations are deleted for every element (associated to baking object)
+            tuple of quantum elements, if no element is provided,
+            all of the baked operations associated to this baking object will be deleted
         """
 
         def remove_Op(q):
@@ -434,7 +434,7 @@ class Baking:
         Retrieve the length of the finalized baked waveform associated to quantum element qe (outside the baking)
 
         :param qe: target quantum element, if None is provided, then length of the longest baked waveform
-            associated to baking object is returned
+            associated to this baking object is returned
         :returns: Length of baked operation associated to element qe (or maximum length if None is provided)
 
         """
@@ -663,7 +663,7 @@ class Baking:
         """
         Add a waveform to the sequence at the specified time index.
         If t is higher than pulse duration for the specified quantum element,
-        a wait command followed by the given waveform at indicated time (in ns) is played.
+        a wait command is inserted until the indicated time (in ns).
         Otherwise, waveform is added (addition of samples) to the pre-existing sequence.
         Finally, providing a negative index starts adding the sample with a prior negative wait of t
         Note that the phase played for the newly formed sample is the one that was set before adding the new waveform

--- a/qualang_tools/bakery/bakery.py
+++ b/qualang_tools/bakery/bakery.py
@@ -3,7 +3,7 @@ Author: Arthur Strauss - Quantum Machines
 Created: 23/02/2021
 """
 
-from typing import List, Union, Tuple
+from typing import List, Union, Tuple, Dict, Optional, Set
 import numpy as np
 from qm import qua
 import copy
@@ -67,7 +67,7 @@ class Baking:
         return self
 
     @property
-    def elements(self):
+    def elements(self) -> Set:
         """
         Return the set of quantum elements involved in the baking
         """
@@ -81,10 +81,10 @@ class Baking:
         return BakingOperations(self)
 
     @property
-    def config(self):
+    def config(self) -> Dict:
         return self._config
 
-    def _find_baking_index(self, baking_index: int = None):
+    def _find_baking_index(self, baking_index: int = None) -> int:
         if baking_index is None:
             max_index = [-1]
             for qe in self._config["elements"].keys():
@@ -119,7 +119,7 @@ class Baking:
 
         return sample_dict, qe_dict, digit_samples_dict
 
-    def _update_config(self, qe, qe_samples):
+    def _update_config(self, qe, qe_samples) -> None:
 
         # Generates new Op, pulse, and waveform for each qe to be added in the original config file
 
@@ -322,10 +322,13 @@ class Baking:
         except KeyError:
             raise KeyError(f"No waveforms found for pulse {pulse}")
 
-    def get_baking_index(self):
+    def get_baking_index(self) -> int:
+        """
+        :return: Index of the baking object (based on its order of creation)
+        """
         return self._ctr
 
-    def get_current_length(self, qe: str):
+    def get_current_length(self, qe: str) -> int:
         """
         Retrieve within the baking the current length of the waveform being created (within the baking)
 
@@ -338,7 +341,7 @@ class Baking:
         else:
             raise KeyError("quantum element not in the config")
 
-    def _get_pulse_index(self, qe):
+    def _get_pulse_index(self, qe) -> int:
         index = 0
         for pulse in self._local_config["pulses"]:
             if pulse.find(f"{qe}_baked_pulse_b{self._ctr}") != -1:
@@ -348,10 +351,15 @@ class Baking:
     def get_qe_set(self):
         return self._qe_set
 
-    def get_waveforms_dict(self):
+    def get_waveforms_dict(self) -> Dict:
+        """
+
+        :return: Dictionary of baked waveforms for all quantum elements, in a format compatible
+            with overrides argument of the add_compiled method of QM API
+        """
         return self.override_waveforms_dict
 
-    def delete_baked_Op(self, *qe_set: str):
+    def delete_baked_Op(self, *qe_set: str) -> None:
         """
         Delete from config baked operation and its associated pulse and waveform(s) for
         specified quantum_elements
@@ -403,11 +411,12 @@ class Baking:
             for qe in self._qe_dict.keys():
                 remove_Op(qe)
 
-    def get_Op_name(self, qe: str):
+    def get_Op_name(self, qe: str) -> str:
         """
         Get the baked operation issued from the baking object for quantum element qe
 
         :param qe: quantum element carrying the baked operation
+        :returns: Name of baked operation associated to element qe
         """
         if not (qe in self._qe_set):
             raise KeyError(
@@ -416,11 +425,13 @@ class Baking:
         else:
             return f"baked_Op_{self._ctr}"
 
-    def get_Op_length(self, qe: str):
+    def get_Op_length(self, qe: str) -> int:
         """
         Retrieve the length of the finalized baked waveform associated to quantum element qe (outside the baking)
 
         :param qe: quantum element
+        :returns: Length of baked operation associated to element qe
+
         """
         if self.update_config:
             if not (qe in self._qe_set):
@@ -443,7 +454,7 @@ class Baking:
         else:
             return self.get_current_length(qe)
 
-    def add_digital_waveform(self, name: str, digital_samples: List[Tuple]):
+    def add_digital_waveform(self, name: str, digital_samples: List[Tuple]) -> None:
         """
         Adds a digital waveform to be attached to a baked operation created using the add_Op method
 
@@ -462,7 +473,7 @@ class Baking:
         qe: str,
         samples: Union[List[float], List[List[float]]],
         digital_marker: str = None,
-    ):
+    ) -> None:
         """
         Adds an operation playable within the baking context manager.
 
@@ -760,7 +771,7 @@ class Baking:
                     f'Op:"{Op}" does not exist in configuration and not manually added (use add_pulse)'
                 )
 
-    def frame_rotation(self, angle: float, qe: str):
+    def frame_rotation(self, angle: float, qe: str) -> None:
         """
         Shift the phase of the oscillator associated with a quantum element by the given angle.
         This is typically used for virtual z-rotations.
@@ -773,7 +784,7 @@ class Baking:
 
         self._update_qe_phase(qe, angle)
 
-    def frame_rotation_2pi(self, angle: float, qe: str):
+    def frame_rotation_2pi(self, angle: float, qe: str) -> None:
         """
         Shift the phase of the oscillator associated with a quantum element by the given angle.
         This is typically used for virtual z-rotations. This performs a frame rotation of 2*π*angle
@@ -784,7 +795,7 @@ class Baking:
 
         self._update_qe_phase(qe, 2 * np.pi * angle)
 
-    def set_detuning(self, qe: str, freq: int):
+    def set_detuning(self, qe: str, freq: int) -> None:
         """Update frequency by adding detuning to original IF set in the config.
         Unlike frame rotation, the detuning will only affect the baked operation and will not stick to the element
 
@@ -793,7 +804,7 @@ class Baking:
         """
         self._qe_dict[qe]["freq"] = freq
 
-    def reset_frame(self, *qe_set: str):
+    def reset_frame(self, *qe_set: str) -> None:
         """
         Used to reset all of the frame updated made up to this statement.
 
@@ -802,7 +813,7 @@ class Baking:
         for qe in qe_set:
             self._update_qe_phase(qe, -self._qe_dict[qe]["phase"])
 
-    def ramp(self, amp: float, duration: int, qe: str):
+    def ramp(self, amp: float, duration: int, qe: str) -> None:
         """
         Analog of ramp function in QUA
 
@@ -818,13 +829,13 @@ class Baking:
             self._samples_dict[qe]["I"] += [0] * duration
         self._update_qe_time(qe, duration)
 
-    def _update_qe_time(self, qe: str, dt: int):
+    def _update_qe_time(self, qe: str, dt: int) -> None:
         self._qe_dict[qe]["time"] += dt
 
-    def _update_qe_phase(self, qe: str, phi: float):
+    def _update_qe_phase(self, qe: str, phi: float) -> None:
         self._qe_dict[qe]["phase"] += phi
 
-    def wait(self, duration: int, *qe_set: str):
+    def wait(self, duration: int, *qe_set: str) -> None:
         """
         Wait for the given duration on all provided elements.
         Here, the wait is simply adding 0 to the existing sample for a given duration.
@@ -856,7 +867,7 @@ class Baking:
                 # Duration is negative so just add for subtraction
                 self._qe_dict[qe]["time_track"] = self._qe_dict[qe]["time"] + duration
 
-    def align(self, *qe_set: str):
+    def align(self, *qe_set: str) -> None:
         """
         Align several quantum elements together.
         All of the quantum elements referenced in *elements will wait for all
@@ -947,7 +958,7 @@ class Baking:
 
                 qua.frame_rotation(self._qe_dict[qe]["phase"], qe)
 
-    def _retrieve_constraint_length(self, baking_index: int = None):
+    def _retrieve_constraint_length(self, baking_index: int = None) -> Optional[int]:
         if baking_index is not None:
             for pulse in self._local_config["pulses"]:
                 if pulse.find(f"baked_pulse_{baking_index}") != -1:
@@ -956,11 +967,11 @@ class Baking:
             return None
 
 
-def deterministic_run(baking_list, j):
+def deterministic_run(baking_list, j) -> None:
     """
     Generates a QUA macro for a binary tree ensuring a synchronized play of operations
     listed in the various baking objects
-    
+
     :param baking_list: Python list of Baking objects
     :param j: QUA int
     """

--- a/qualang_tools/bakery/randomized_benchmark.py
+++ b/qualang_tools/bakery/randomized_benchmark.py
@@ -43,10 +43,11 @@ class RBOneQubit:
     def __init__(self, config: dict, d_max: int, K: int, qubit: str):
         """
         Class to retrieve easily baked RB sequences and their inverse operations
-        :param config Configuration file
-        :param d_max Maximum length of desired RB sequence
-        :param K Number of RB sequences
-        :param qubit Name of the quantum element designating the qubit
+
+        :param config: Configuration file
+        :param d_max: Maximum length of desired RB sequence
+        :param K: Number of RB sequences
+        :param qubit: Name of the quantum element designating the qubit
         """
         if not (qubit in config["elements"]):
             raise KeyError(f"Quantum element {qubit} is not in the config")
@@ -59,17 +60,23 @@ class RBOneQubit:
 
 def find_revert_op(input_state_index: int):
     """Looks in the Cayley table the operation needed to reset the state to ground state from input state_tracker
-    :param input_state_index Index of the current state tracker
-    :return index of the next Clifford to apply to invert RB sequence"""
+
+    :param input_state_index: Index of the current state tracker
+    :return: index of the next Clifford to apply to invert RB sequence
+    """
     for i in range(len(c1_ops)):
         if c1_table[input_state_index][i] == 0:
             return i
 
 
 def play_revert_op(index: int, baked_cliffords):
-    """Plays an operation resetting qubit in its ground state based on the
+    """
+    Plays an operation resetting qubit in its ground state based on the
     transformation provided by the index in Cayley table (switch using baked Cliffords)
-    :param index index of the transformed qubit state"""
+
+    :param baked_cliffords: list of baked cliffords (generated using method generate_cliffords)
+    :param index: index of the transformed qubit state
+    """
 
     with switch_(index):
         for i in range(len(baked_cliffords)):
@@ -96,9 +103,12 @@ class RBSequence:
         self.sequence = self.generate_RB_sequence()  # Store the RB sequence
 
     def play_revert_op2(self, index: int):
-        """Plays an operation resetting qubit in its ground state based on the
+        """
+        Plays an operation resetting qubit in its ground state based on the
         transformation provided by the index in Cayley table (explicit switch case)
-        :param index index of the transformed qubit state"""
+
+        :param index: index of the transformed qubit state
+        """
         qubit = self.qubit
 
         with switch_(index):
@@ -175,6 +185,8 @@ class RBSequence:
     def generate_cliffords(self):
         """
         Returns a list of baking object giving access to baked Clifford waveforms
+
+        :return: List of baking objects to play each Clifford
         """
 
         baked_clifford = [None] * len(c1_ops)

--- a/qualang_tools/tests/test_bakery.py
+++ b/qualang_tools/tests/test_bakery.py
@@ -338,8 +338,8 @@ def test_play_baked_with_existing_digital_wf(config):
 def test_constraint_length(config):
     cfg = deepcopy(config)
     with baking(cfg) as b:
-        b.add_Op("Op", "qe1", [0.2]*1000)
-        b.add_Op("Op2", "qe2", [[0.2]*700, [0.3]*700])
+        b.add_Op("Op", "qe1", [0.2] * 1000)
+        b.add_Op("Op2", "qe2", [[0.2] * 700, [0.3] * 700])
         b.play("Op", "qe1")
         b.play("Op2", "qe2")
 

--- a/qualang_tools/tests/test_bakery.py
+++ b/qualang_tools/tests/test_bakery.py
@@ -333,3 +333,23 @@ def test_play_baked_with_existing_digital_wf(config):
     job = simulate_program_and_return(cfg, prog)
     samples = job.get_simulated_samples()
     assert len(samples.con1.digital["1"] > 0)
+
+
+def test_constraint_length(config):
+    cfg = deepcopy(config)
+    with baking(cfg) as b:
+        b.add_Op("Op", "qe1", [0.2]*1000)
+        b.add_Op("Op2", "qe2", [[0.2]*700, [0.3]*700])
+        b.play("Op", "qe1")
+        b.play("Op2", "qe2")
+
+    assert b.get_Op_length() == 1000
+
+    with baking(cfg, baking_index=b.get_baking_index()) as b2:
+        b2.add_Op("Op", "qe1", [0.2] * 300)
+        b2.add_Op("Op2", "qe2", [[0.2] * 700, [0.3] * 700])
+        b2.play("Op", "qe1")
+        b2.play("Op2", "qe2")
+
+    assert b2.get_Op_length() == 1000
+    assert b2.get_Op_length("qe1") == 1000 == b2.get_Op_length("qe2")


### PR DESCRIPTION
Documentation is now more explicit within the docstrings.
It is now possible to retrieve easily the length of the biggest baked waveform (without having to know which element contains it) for a specific baking object