### PR TITLE
Integration weights tool - Converted list to numpy array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 - Add experimental feature - [InteractivePlotLib](https://github.com/qua-platform/py-qua-tools/tree/main/qualang_tools/addons).
-  This plotting library, built on Matplotlib, adds many new features to it. 
+  This plotting library, built on Matplotlib, adds many new features to it.
+### Fixed
+- Integration weights tool - Fixed a bug which caused the integration weight tool to not work on lists
 
 ## [0.6.5] - 2022-01-26
 ### Changed

--- a/qualang_tools/config/integration_weights_tools.py
+++ b/qualang_tools/config/integration_weights_tools.py
@@ -26,6 +26,7 @@ def convert_integration_weights(
     :type plot: bool
     :return: List of tuples representing the integration weights
     """
+    integration_weights = np.array(integration_weights)
     integration_weights = _round_to_fixed_point_accuracy(integration_weights, accuracy)
     changes_indices = np.where(np.abs(np.diff(integration_weights)) > 0)[0].tolist()
     prev_index = -1
@@ -98,6 +99,8 @@ def plot_integration_weights(integration_weights):
         a = [[i] * 4 for i in integration_weights]
         unpacked_weights = sum(a, start=[])
         label = "Original"
+    else:
+        raise Exception("Unknown input")
 
     plt.plot(unpacked_weights, label=label)
     plt.legend()

--- a/tests/test_integration_weights_tools.py
+++ b/tests/test_integration_weights_tools.py
@@ -13,7 +13,7 @@ def abs_path_to(rel_path: str) -> str:
 
 
 def test_validity_arbitrary_integration_weights():
-    weights_before = np.load(abs_path_to("iw1_cos1.npy"))
+    weights_before = np.load(abs_path_to("iw1_cos1.npy")).tolist()
     weights_after = convert_integration_weights(weights_before, N=len(weights_before))
     ii = 0
     for i in range(len(weights_after) // 4):
@@ -24,6 +24,6 @@ def test_validity_arbitrary_integration_weights():
 
 
 def test_compression_arbitrary_integration_weights():
-    weights_before = np.load(abs_path_to("iw1_cos1.npy"))
+    weights_before = np.load(abs_path_to("iw1_cos1.npy")).tolist()
     weights_after = convert_integration_weights(weights_before, N=500)
     assert sum([i[1] for i in weights_after]) == 4 * len(weights_before)


### PR DESCRIPTION
Fixed a bug which caused the tool to fail when inputting a list