### PR TITLE
FIxed init bug and units

### DIFF
--- a/qualang_tools/results/__init__.py
+++ b/qualang_tools/results/__init__.py
@@ -1,4 +1,4 @@
-from qualang_tools.results.results import result_tool
+from qualang_tools.results.results import fetching_tool
 from qualang_tools.results.results import progress_counter
 
-__all__ = ["result_tool", "progress_counter"]
+__all__ = ["fetching_tool", "progress_counter"]

--- a/qualang_tools/units/units.py
+++ b/qualang_tools/units/units.py
@@ -40,7 +40,7 @@ class unit:
             print(
                 f"Warning: the specified duration ({t}) to be converted to clock cycles in not an integer. It has been converted to int ({int(t)}) to avoid subsequent errors."
             )
-            t = int(t)
+            t = int(t * self.ns)
         return t // 4
 
     def demod2volts(self, data, duration):
@@ -50,7 +50,7 @@ class unit:
         :param duration: demodulation duration in ns.
         :return: the demodulated data in volts.
         """
-        return 4096 * data / duration
+        return 4096 * data * self.V / duration
 
     def raw2volts(self, data):
         """Converts the raw data to volts.
@@ -58,4 +58,4 @@ class unit:
         :param data: raw data. Must be a python variable or array.
         :return: the raw data in volts.
         """
-        return data / 4096
+        return data * self.V / 4096


### PR DESCRIPTION
There was a bug in the results init (wrong function name)
And I added a self call in the unit function to remove static warnings