### PR TITLE
Renamed arguments in Element and MeasureElement classes #124

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+### Changed
+- ConfigBuilder - renamed arguments (backward compatible) in Element and MeasureElement classes.
 
 ## [0.11.1] - 2022-07-19
 ### Fixed

--- a/qualang_tools/config/exceptions.py
+++ b/qualang_tools/config/exceptions.py
@@ -1,4 +1,19 @@
+import warnings
+import re
+
+
 class ConfigurationError(Exception):
     def __init__(self, message) -> None:
         self.message = message
         super().__init__(self.message)
+
+
+def _warn_if_not_none(kwargs, deprecated_arg):
+    suggested_arg = "element_" + re.split("_ports", deprecated_arg)[0] + "s"
+    val = kwargs.get(deprecated_arg, None)
+    if val is not None:
+        warnings.warn(
+            "{0} is deprecated use {1}".format(deprecated_arg, suggested_arg),
+            DeprecationWarning,
+        )
+    return val

--- a/tests/test_config_builder.py
+++ b/tests/test_config_builder.py
@@ -382,3 +382,26 @@ def test_parameter_algebra():
     assert (c / 10)() == c() / 10
     assert (d**c)() == 10000
     assert (c**2)() == 16
+
+
+def test_deprecated_warning():
+    with pytest.warns(None) as record:
+        cb = ConfigBuilder()
+        cont = Controller("con1")
+        cb.add(cont)
+        elm = Element("elm", analog_input_ports=[cont.analog_output(1)]
+        )
+
+        cb.add(elm)
+        cb.build()
+    assert len(record.list) == 1
+
+    with pytest.warns(None) as record:
+        cb = ConfigBuilder()
+        cont = Controller("con1")
+        cb.add(cont)
+        elm = Element("elm", element_analog_inputs=[cont.analog_output(1)]
+        )
+        cb.add(elm)
+        cb.build()
+    assert len(record.list) == 0


### PR DESCRIPTION
Renamed the argument names in `Element` and `MeasureElement` classes.
For e.g. we use `element_analog_inputs` instead of `analog_input_ports`, we still support the old arguments with a `DeprecationWarning`.


