### PR TITLE
small fix on waveform_tools for type inference

### DIFF
--- a/qualang_tools/config/waveform_tools.py
+++ b/qualang_tools/config/waveform_tools.py
@@ -8,7 +8,7 @@ def drag_gaussian_pulse_waveforms(
     sigma,
     alpha,
     anharmonicity,
-    detuning=0,
+    detuning=0.0,
     subtracted=True,
     **kwargs
 ):
@@ -94,7 +94,7 @@ def drag_gaussian_pulse_waveforms(
 
 
 def drag_cosine_pulse_waveforms(
-    amplitude, length, alpha, anharmonicity, detuning=0, **kwargs
+    amplitude, length, alpha, anharmonicity, detuning=0.0, **kwargs
 ):
     """
     Creates Cosine based DRAG waveforms that compensate for the leakage and for the AC stark shift.


### PR DESCRIPTION
The default arguments for `drag_*_pulse_waveforms` were as the following:
```python
def drag_cosine_pulse_waveforms(
    amplitude, length, alpha, anharmonicity, detuning=0, **kwargs
):
...
```

Type inference (for example by pylance) analyzes it as `detuning: int`. Thus, an example usage of `drag_gaussian_pulse_waveforms(..., detuning=1.5e6, ...)` has been marked as wrong type was passed. I just changed `detuing=0` to `detuning=0.0`.