### PR TITLE
fixes to bakery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 ### Added
-
 - Multi-user Tools - A subpackage that allows several users to work simultaneously.
 - Config.helper_tools - This package includes tools for writing and updating the configuration.
 - Plot.fitting - This tool enables the use to fit results from qua programs.
+- Bakery - Added a flag to disable the addition of an `align` to the `run` function.
 
 ### Changed
 - Plot.plots - Added functions to plot results from qua programs (`plot_demodulated_data 1D and 2D`, `get_simulated_samples_by_element` and `plot_simulator_output`)
+- Bakery - Now uses the more efficient `frame_rotation_2pi` instead of `frame_rotation`.
+
+### Fixed
+- Bakery - Fixed cases in which a `frame_rotation_2pi(0.0)` was added .
 
 ## [0.12.0] - 2022-08-29
 ### Changed

--- a/qualang_tools/bakery/README.md
+++ b/qualang_tools/bakery/README.md
@@ -99,7 +99,8 @@ It is also possible to delete samples within the baking context manager using th
        
 # **How to play in QUA my baked waveforms?**
 
-The baking object has a method called run, which takes no inputs and simply does appropriate alignment between quantum elements involved in the baking and play simultaneously (using this time a QUA play statement) the previously baked waveforms.
+The baking object has a method called run, which aligns all the elements involved in the baking and then plays them simultaneously.
+It is possible to disable this alignment, in order to reduce possible gaps.
 Therefore, all that is left is to **call the run method associated to the baking object within the actual QUA program**.
 
 ```python


### PR DESCRIPTION
- Bakery - Added a flag to disable the addition of an `align` to the `run` function.
- Bakery - Now uses the more efficient `frame_rotation_2pi` instead of `frame_rotation`.
- Bakery - Fixed cases in which a `frame_rotation_2pi(0.0)` was added .