### PR TITLE
Update the import of qm.Program in units.py

### DIFF
--- a/qualang_tools/units/units.py
+++ b/qualang_tools/units/units.py
@@ -7,7 +7,7 @@ Content:
     - raw2volts: converts raw data to volts.
 """
 
-from qm.program._Program import _Program
+from qm import Program
 from inspect import stack
 from warnings import warn
 from typing import Union
@@ -24,10 +24,10 @@ class _nanosecond:
             for var in frameinfo.frame.f_locals.values():
 
                 if isinstance(
-                    var, _Program
+                    var, Program
                 ):  # we have a qua program being declared somewhere
                     if (
-                        var._is_in_scope  # this is set by __enter__ and unset by __exit__ of _Program
+                        var._is_in_scope  # this is set by __enter__ and unset by __exit__ of Program
                     ):
                         return 0.25  # now it is in clock cycles
         else:


### PR DESCRIPTION
The old import message raised the following warning: `DeprecationWarning: 'qm.program._Program' is moved as of 1.1.0 and will be removed in 1.2.0. use 'qm.Program' instead`