### PR TITLE
simulator tools -> better create connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+### Added
+- simulator_tools - ``create_simulator_controller_connections`` can now be used to create the connections between a subset of a large cluster.
+
 ### Changed
 - config/waveform_tools - Added sampling rate argument with default value set to 1GS/s to the waveforms.
+- simulator_tools - ``create_simulator_controller_connections`` now creates the connections with a different algorithm that uses all available optical connections.
+- simulator_tools - ``create_simulator_controller_connections`` order of input parameters has changed.
+
+### Deprecated
+- simulator_tools - ``qualang_tools.simulator_tools`` has been deprecated and was moved to ``qualang_tools.simulator``.
 
 ## [0.16.0] - 2024-01-25
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
-- simulator_tools - ``create_simulator_controller_connections`` can now be used to create the connections between a subset of a large cluster.
+- simulator - ``create_simulator_controller_connections`` can now be used to create the connections between a subset of a large cluster.
 
 ### Changed
 - config/waveform_tools - Added sampling rate argument with default value set to 1GS/s to the waveforms.
-- simulator_tools - ``create_simulator_controller_connections`` now creates the connections with a different algorithm that uses all available optical connections.
-- simulator_tools - ``create_simulator_controller_connections`` order of input parameters has changed.
+- simulator - ``create_simulator_controller_connections`` now creates the connections with a different algorithm that uses all available optical connections.
+- simulator - ``create_simulator_controller_connections`` order of input parameters has changed.
 
 ### Deprecated
-- simulator_tools - ``qualang_tools.simulator_tools`` has been deprecated and was moved to ``qualang_tools.simulator``.
+- simulator - ``qualang_tools.simulator_tools`` has been deprecated and was moved to ``qualang_tools.simulator``.
 
 ## [0.16.0] - 2024-01-25
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ It includes:
 * [Analysis Tools](qualang_tools/analysis/README.md) - This library includes tools for analyzing data from experiments. 
 It currently has a two-states discriminator for analyzing the ground and excited IQ blobs.
 * [Multi-user tools](qualang_tools/multi_user/README.md) - This library includes tools for working with the QOP in a multi-user or multi-process setting.
+* [Simulator tools](qualang_tools/simulator/README.md) - This library includes tools for creating simulations.
 
 * [Bakery](qualang_tools/bakery/README.md) - This library introduces a new framework for creating arbitrary waveforms and
 storing them in the usual configuration file. It allows defining waveforms in a QUA-like manner while working with 1ns resolution (or higher).

--- a/qualang_tools/__init__.py
+++ b/qualang_tools/__init__.py
@@ -1,5 +1,5 @@
 __all__ = [
-    "simulator_tools",
+    "simulator",
     "bakery",
     "config",
     "control_panel",

--- a/qualang_tools/results/README.md
+++ b/qualang_tools/results/README.md
@@ -20,7 +20,7 @@ n_avg = 1000
 with program() as prog:
     # QUA program with n_avg averaging iterations
 
-qmm = QuantumMachinesManager(qop_ip, cluster_name)
+qmm = QuantumMachinesManager(host=qop_ip, port=qop_port, cluster_name=cluster_name)
 qm = qmm.open_qm(config)
 job = qm.execute(prog)
 

--- a/qualang_tools/results/README.md
+++ b/qualang_tools/results/README.md
@@ -17,10 +17,10 @@ Then the results can be fetched with the `.fetch_all()` method while the program
 from qualang_tools.results import fetching_tool
 
 n_avg = 1000
-with program as prog:
+with program() as prog:
     # QUA program with n_avg averaging iterations
 
-qmm = QuantumMachinesManager(host="127.0.0.1", port="80")
+qmm = QuantumMachinesManager(qop_ip, cluster_name)
 qm = qmm.open_qm(config)
 job = qm.execute(prog)
 

--- a/qualang_tools/simulator/README.md
+++ b/qualang_tools/simulator/README.md
@@ -3,8 +3,8 @@ This library includes tools to help simulate programs
 
 ## create_simulator_controller_connections
 Creates a list of :class:`~qm.simulate.interface.ControllerConnection` objects with the Inter-controllers connections between controllers in a way which maximizes the optical links connectivity.
-For use inside the :class:`~qm.simulate.interface.SimulationConfig` for simulating the controllers` behavior.
-Can be used to also simulate part of a small cluster: For example, the following command would create all the connections
+For use inside the :class:`~qm.simulate.interface.SimulationConfig` for simulating the controllers' behavior.
+It can be used to also simulate part of a small cluster: For example, the following command would create all the connections
 needed to run a simulation on 'con1', 'con4', 'con5' which are part of a 9 OPX cluster: `create_simulator_controller_connections(9, [1,4,5])`
 
 ### Usage example
@@ -15,7 +15,7 @@ from qualang_tools.simulator import create_simulator_controller_connections
 with program() as prog:
     # QUA program 
 
-qmm = QuantumMachinesManager(qop_ip, cluster_name)
+qmm = QuantumMachinesManager(host=qop_ip, port=qop_port, cluster_name=cluster_name)
 job = qmm.simulate(config,
                    prog,
                    SimulationConfig(simulation_duration,
@@ -29,7 +29,7 @@ from qualang_tools.simulator import create_simulator_controller_connections
 with program() as prog:
     # QUA program 
 
-qmm = QuantumMachinesManager(qop_ip, cluster_name)
+qmm = QuantumMachinesManager(host=qop_ip, port=qop_port, cluster_name=cluster_name)
 job = qmm.simulate(config,
                    prog,
                    SimulationConfig(simulation_duration,

--- a/qualang_tools/simulator/README.md
+++ b/qualang_tools/simulator/README.md
@@ -1,0 +1,43 @@
+# Simulator tools
+This library includes tools to help simulate programs
+
+## create_simulator_controller_connections
+Creates a list of :class:`~qm.simulate.interface.ControllerConnection` objects with the Inter-controllers connections between controllers in a way which maximizes the optical links connectivity.
+For use inside the :class:`~qm.simulate.interface.SimulationConfig` for simulating the controllers` behavior.
+Can be used to also simulate part of a small cluster: For example, the following command would create all the connections
+needed to run a simulation on 'con1', 'con4', 'con5' which are part of a 9 OPX cluster: `create_simulator_controller_connections(9, [1,4,5])`
+
+### Usage example
+A simple example for a 3 OPX cluster:
+```python
+from qualang_tools.simulator import create_simulator_controller_connections
+
+with program() as prog:
+    # QUA program 
+
+qmm = QuantumMachinesManager(qop_ip, cluster_name)
+job = qmm.simulate(config,
+                   prog,
+                   SimulationConfig(simulation_duration,
+                                    controller_connections=create_simulator_controller_connections(3)))
+```
+ 
+A simulation running on 'con1', 'con4', 'con5' which are part of a 9 OPX cluster, which also has loopback connected between the controllers:
+```python
+from qualang_tools.simulator import create_simulator_controller_connections
+
+with program() as prog:
+    # QUA program 
+
+qmm = QuantumMachinesManager(qop_ip, cluster_name)
+job = qmm.simulate(config,
+                   prog,
+                   SimulationConfig(simulation_duration,
+                                    simulation_interface=LoopbackInterface([('con1', 1, 'con4', 1),
+                                                                            ('con1', 2, 'con4', 2),
+                                                                            ('con4', 1, 'con1', 1),
+                                                                            ('con4', 2, 'con1', 2),
+                                                                            ],
+                                                                           latency=168),
+                                    controller_connections=create_simulator_controller_connections(9, [1,4,5])))
+```

--- a/qualang_tools/simulator/__init__.py
+++ b/qualang_tools/simulator/__init__.py
@@ -1,0 +1,5 @@
+from qualang_tools.simulator.simulator import create_simulator_controller_connections
+
+__all__ = [
+    "create_simulator_controller_connections",
+]

--- a/qualang_tools/simulator/simulator.py
+++ b/qualang_tools/simulator/simulator.py
@@ -1,0 +1,52 @@
+import numpy as np
+from qm import ControllerConnection, InterOpxChannel
+
+
+def create_simulator_controller_connections(
+    n_controllers, actual_controllers=None, n_connections=12, print_debug=False
+):
+    """
+    Creates a list of :class:`~qm.simulate.interface.ControllerConnection` objects with the Inter-controllers
+    connections between controllers in a way which maximizes the optical links connectivity
+    For use inside the :class:`~qm.simulate.interface.SimulationConfig` for simulating the controllers` behavior.
+
+    :param n_controllers: The number of controllers
+    :type n_controllers: int
+    :param actual_controllers: A list of the controllers actually being used in the simulation
+    :type actual_controllers: List[int]
+    :param n_connections: The number of optical connectors each controller has, default is 12
+    :type n_connections: int
+    :param print_debug: If true, prints the connections to the terminal
+    :type print_debug: bool
+    :returns: The ControllerConnection object
+
+    """
+    if not actual_controllers:
+        actual_controllers = [i + 1 for i in range(n_controllers)]
+    controller_connections = []
+    unused_connection = np.ones((n_controllers, n_connections), dtype=bool)
+    while unused_connection.any():
+        for i in range(n_controllers):
+            for j in range(i + 1, n_controllers):
+                first_con_port = np.nonzero(unused_connection[i, :])[0]
+                if first_con_port.size == 0:
+                    break
+                first_con_port = first_con_port[0]
+                second_con_port = np.nonzero(unused_connection[j, :])[0]
+                if second_con_port.size == 0:
+                    break
+                second_con_port = second_con_port[0]
+                if i + 1 in actual_controllers and j + 1 in actual_controllers:
+                    controller_connections.append(
+                        ControllerConnection(
+                            InterOpxChannel(f"con{i+1}", first_con_port), InterOpxChannel(f"con{j+1}", second_con_port)
+                        )
+                    )
+                    if print_debug:
+                        print(f"con{i + 1}:{first_con_port} <-> con{j + 1}, {second_con_port}")
+                elif print_debug:
+                    print(f"con{i + 1}:{first_con_port} <-> con{j + 1}, {second_con_port} - Skipped")
+                unused_connection[i, first_con_port] = False
+                unused_connection[j, second_con_port] = False
+
+    return controller_connections

--- a/qualang_tools/simulator/simulator.py
+++ b/qualang_tools/simulator/simulator.py
@@ -7,12 +7,12 @@ def create_simulator_controller_connections(
 ):
     """
     Creates a list of :class:`~qm.simulate.interface.ControllerConnection` objects with the Inter-controllers
-    connections between controllers in a way which maximizes the optical links connectivity
+    connections between controllers in a way which maximizes the optical links connectivity.
     For use inside the :class:`~qm.simulate.interface.SimulationConfig` for simulating the controllers` behavior.
 
     :param n_controllers: The number of controllers
     :type n_controllers: int
-    :param actual_controllers: A list of the controllers actually being used in the simulation
+    :param actual_controllers: A list of the controllers actually being used in the simulation. For `con1` & `con2` use [1,2].
     :type actual_controllers: List[int]
     :param n_connections: The number of optical connectors each controller has, default is 12
     :type n_connections: int
@@ -21,6 +21,8 @@ def create_simulator_controller_connections(
     :returns: The ControllerConnection object
 
     """
+    if n_controllers == 1:
+        return []
     if not actual_controllers:
         actual_controllers = [i + 1 for i in range(n_controllers)]
     controller_connections = []

--- a/qualang_tools/simulator_tools.py
+++ b/qualang_tools/simulator_tools.py
@@ -1,7 +1,8 @@
+import numpy as np
 from qm import ControllerConnection, InterOpxChannel
 
 
-def create_simulator_controller_connections(n_controllers, n_connections=12):
+def create_simulator_controller_connections(n_controllers, n_connections=12, old_method=False, n_actual_controllers=None):
     """
     Creates a list of :class:`~qm.simulate.interface.ControllerConnection` objects with all of the Inter-controllers
     connections according to the `recommended schema
@@ -15,35 +16,66 @@ def create_simulator_controller_connections(n_controllers, n_connections=12):
     :returns: The ControllerConnection object
 
     """
-    if n_controllers == 1:
-        return None
-
-    ncbc = n_connections // (n_controllers - 1)  # ncbc = number_of_connections_between_controllers
-    n_connections = ncbc * (n_controllers - 1)
-    first_controller_list = []
-    first_port_list = []
-    second_controller_list = []
-    second_port_list = []
-    for i in range(n_controllers):
-        first_controller_list = first_controller_list + [i + 1] * (n_connections - i * ncbc)
-
-        first_port_list = first_port_list + [j for j in range(i * ncbc, n_connections)]
-
-        for j in range(i + 1, n_controllers):
-            second_controller_list = second_controller_list + [j + 1] * ncbc
-
-        second_port_list = second_port_list + [j for j in range(i * ncbc, (i + 1) * ncbc)] * (n_controllers - i - 1)
-
-    controller_connections = [
-        ControllerConnection(InterOpxChannel(f"con{i}", j), InterOpxChannel(f"con{k}", l))
-        for i, j, k, l in list(
-            zip(
-                first_controller_list,
-                first_port_list,
-                second_controller_list,
-                second_port_list,
+    if not old_method:
+        if not n_actual_controllers:
+            n_actual_controllers = n_controllers
+        controller_connections = []
+        unused_connection = np.ones((n_controllers, n_connections), dtype=bool)
+        while unused_connection.any():
+            for i in range(n_controllers):
+                for j in range(i + 1, n_controllers):
+                    first_con_port = np.nonzero(unused_connection[i, :])[0]
+                    if first_con_port.size == 0:
+                        break
+                    first_con_port = first_con_port[0]
+                    second_con_port = np.nonzero(unused_connection[j, :])[0]
+                    if second_con_port.size == 0:
+                        break
+                    second_con_port = second_con_port[0]
+                    if i < n_actual_controllers and j < n_actual_controllers:
+                        controller_connections.append(
+                            ControllerConnection(
+                                InterOpxChannel(f"con{i+1}", first_con_port),
+                                InterOpxChannel(f"con{j+1}", second_con_port))
+                        )
+                    print(f"con{i+1}:{first_con_port} <-> con{j+1}, {second_con_port}")
+                    unused_connection[i, first_con_port] = False
+                    unused_connection[j, second_con_port] = False
+    else:
+        ncbc = n_connections // (
+            n_controllers - 1
+        )  # ncbc = number_of_connections_between_controllers
+        n_connections = ncbc * (n_controllers - 1)
+        first_controller_list = []
+        first_port_list = []
+        second_controller_list = []
+        second_port_list = []
+        for i in range(n_controllers):
+            first_controller_list = first_controller_list + [i + 1] * (
+                n_connections - i * ncbc
             )
-        )
-    ]
+
+            first_port_list = first_port_list + [j for j in range(i * ncbc, n_connections)]
+
+            for j in range(i + 1, n_controllers):
+                second_controller_list = second_controller_list + [j + 1] * ncbc
+
+            second_port_list = second_port_list + [
+                j for j in range(i * ncbc, (i + 1) * ncbc)
+            ] * (n_controllers - i - 1)
+
+        controller_connections = [
+            ControllerConnection(
+                InterOpxChannel(f"con{i}", j), InterOpxChannel(f"con{k}", l)
+            )
+            for i, j, k, l in list(
+                zip(
+                    first_controller_list,
+                    first_port_list,
+                    second_controller_list,
+                    second_port_list,
+                )
+            )
+        ]
 
     return controller_connections

--- a/qualang_tools/simulator_tools.py
+++ b/qualang_tools/simulator_tools.py
@@ -1,50 +1,14 @@
-import numpy as np
-from qm import ControllerConnection, InterOpxChannel
+from qualang_tools.simulator import create_simulator_controller_connections
+import warnings
 
+__all__ = [
+    "create_simulator_controller_connections",
+]
 
-def create_simulator_controller_connections(n_controllers, actual_controllers=None, n_connections=12, print_debug=False):
-    """
-    Creates a list of :class:`~qm.simulate.interface.ControllerConnection` objects with the Inter-controllers
-    connections between controllers in a way which maximizes the optical links connectivity
-    For use inside the :class:`~qm.simulate.interface.SimulationConfig` for simulating the controllers` behavior.
-
-    :param n_controllers: The number of controllers
-    :type n_controllers: int
-    :param actual_controllers: A list of the controllers actually being used in the simulation
-    :type actual_controllers: List[int]
-    :param n_connections: The number of optical connectors each controller has, default is 12
-    :type n_connections: int
-    :param print_debug: If true, prints the connections to the terminal
-    :type print_debug: bool
-    :returns: The ControllerConnection object
-
-    """
-    if not actual_controllers:
-        actual_controllers = [i+1 for i in range(n_controllers)]
-    controller_connections = []
-    unused_connection = np.ones((n_controllers, n_connections), dtype=bool)
-    while unused_connection.any():
-        for i in range(n_controllers):
-            for j in range(i + 1, n_controllers):
-                first_con_port = np.nonzero(unused_connection[i, :])[0]
-                if first_con_port.size == 0:
-                    break
-                first_con_port = first_con_port[0]
-                second_con_port = np.nonzero(unused_connection[j, :])[0]
-                if second_con_port.size == 0:
-                    break
-                second_con_port = second_con_port[0]
-                if i+1 in actual_controllers and j+1 in actual_controllers:
-                    controller_connections.append(
-                        ControllerConnection(
-                            InterOpxChannel(f"con{i+1}", first_con_port),
-                            InterOpxChannel(f"con{j+1}", second_con_port))
-                    )
-                    if print_debug:
-                        print(f"con{i + 1}:{first_con_port} <-> con{j + 1}, {second_con_port}")
-                elif print_debug:
-                    print(f"con{i + 1}:{first_con_port} <-> con{j + 1}, {second_con_port} - Skipped")
-                unused_connection[i, first_con_port] = False
-                unused_connection[j, second_con_port] = False
-
-    return controller_connections
+warnings.warn(
+    "The 'create_simulator_controller_connections' function has been moved to 'qualang_tools.simulator'.", FutureWarning
+)
+warnings.warn(
+    "The 'create_simulator_controller_connections' function has been moved to 'qualang_tools.simulator'.",
+    DeprecationWarning,
+)

--- a/qualang_tools/simulator_tools.py
+++ b/qualang_tools/simulator_tools.py
@@ -2,80 +2,49 @@ import numpy as np
 from qm import ControllerConnection, InterOpxChannel
 
 
-def create_simulator_controller_connections(n_controllers, n_connections=12, old_method=False, n_actual_controllers=None):
+def create_simulator_controller_connections(n_controllers, actual_controllers=None, n_connections=12, print_debug=False):
     """
-    Creates a list of :class:`~qm.simulate.interface.ControllerConnection` objects with all of the Inter-controllers
-    connections according to the `recommended schema
-    <https://qm-docs.qualang.io/hardware/opx+installation#inter-controller-optical-connectivity-scheme>`__.
+    Creates a list of :class:`~qm.simulate.interface.ControllerConnection` objects with the Inter-controllers
+    connections between controllers in a way which maximizes the optical links connectivity
     For use inside the :class:`~qm.simulate.interface.SimulationConfig` for simulating the controllers` behavior.
 
     :param n_controllers: The number of controllers
     :type n_controllers: int
+    :param actual_controllers: A list of the controllers actually being used in the simulation
+    :type actual_controllers: List[int]
     :param n_connections: The number of optical connectors each controller has, default is 12
     :type n_connections: int
+    :param print_debug: If true, prints the connections to the terminal
+    :type print_debug: bool
     :returns: The ControllerConnection object
 
     """
-    if not old_method:
-        if not n_actual_controllers:
-            n_actual_controllers = n_controllers
-        controller_connections = []
-        unused_connection = np.ones((n_controllers, n_connections), dtype=bool)
-        while unused_connection.any():
-            for i in range(n_controllers):
-                for j in range(i + 1, n_controllers):
-                    first_con_port = np.nonzero(unused_connection[i, :])[0]
-                    if first_con_port.size == 0:
-                        break
-                    first_con_port = first_con_port[0]
-                    second_con_port = np.nonzero(unused_connection[j, :])[0]
-                    if second_con_port.size == 0:
-                        break
-                    second_con_port = second_con_port[0]
-                    if i < n_actual_controllers and j < n_actual_controllers:
-                        controller_connections.append(
-                            ControllerConnection(
-                                InterOpxChannel(f"con{i+1}", first_con_port),
-                                InterOpxChannel(f"con{j+1}", second_con_port))
-                        )
-                    print(f"con{i+1}:{first_con_port} <-> con{j+1}, {second_con_port}")
-                    unused_connection[i, first_con_port] = False
-                    unused_connection[j, second_con_port] = False
-    else:
-        ncbc = n_connections // (
-            n_controllers - 1
-        )  # ncbc = number_of_connections_between_controllers
-        n_connections = ncbc * (n_controllers - 1)
-        first_controller_list = []
-        first_port_list = []
-        second_controller_list = []
-        second_port_list = []
+    if not actual_controllers:
+        actual_controllers = [i+1 for i in range(n_controllers)]
+    controller_connections = []
+    unused_connection = np.ones((n_controllers, n_connections), dtype=bool)
+    while unused_connection.any():
         for i in range(n_controllers):
-            first_controller_list = first_controller_list + [i + 1] * (
-                n_connections - i * ncbc
-            )
-
-            first_port_list = first_port_list + [j for j in range(i * ncbc, n_connections)]
-
             for j in range(i + 1, n_controllers):
-                second_controller_list = second_controller_list + [j + 1] * ncbc
-
-            second_port_list = second_port_list + [
-                j for j in range(i * ncbc, (i + 1) * ncbc)
-            ] * (n_controllers - i - 1)
-
-        controller_connections = [
-            ControllerConnection(
-                InterOpxChannel(f"con{i}", j), InterOpxChannel(f"con{k}", l)
-            )
-            for i, j, k, l in list(
-                zip(
-                    first_controller_list,
-                    first_port_list,
-                    second_controller_list,
-                    second_port_list,
-                )
-            )
-        ]
+                first_con_port = np.nonzero(unused_connection[i, :])[0]
+                if first_con_port.size == 0:
+                    break
+                first_con_port = first_con_port[0]
+                second_con_port = np.nonzero(unused_connection[j, :])[0]
+                if second_con_port.size == 0:
+                    break
+                second_con_port = second_con_port[0]
+                if i+1 in actual_controllers and j+1 in actual_controllers:
+                    controller_connections.append(
+                        ControllerConnection(
+                            InterOpxChannel(f"con{i+1}", first_con_port),
+                            InterOpxChannel(f"con{j+1}", second_con_port))
+                    )
+                    if print_debug:
+                        print(f"con{i + 1}:{first_con_port} <-> con{j + 1}, {second_con_port}")
+                elif print_debug:
+                    print(f"con{i + 1}:{first_con_port} <-> con{j + 1}, {second_con_port} - Skipped")
+                unused_connection[i, first_con_port] = False
+                unused_connection[j, second_con_port] = False
 
     return controller_connections

--- a/tests/test_simulator_tools.py
+++ b/tests/test_simulator_tools.py
@@ -1,7 +1,6 @@
-import pytest
 from qm import ControllerConnection, InterOpxChannel
 
-from qualang_tools.simulator_tools import create_simulator_controller_connections
+from qualang_tools.simulator import create_simulator_controller_connections
 
 
 def test_two_controllers_connection_schema():
@@ -22,17 +21,17 @@ def test_two_controllers_connection_schema():
             )
         )
     ]
-    generated_controller_connections = create_simulator_controller_connections(2, 12)
+    generated_controller_connections = create_simulator_controller_connections(2)
     assert len(controller_connections) == len(generated_controller_connections)
     for a, b in zip(controller_connections, generated_controller_connections):
         assert (a.source == b.source) & (a.target == b.target)
 
 
 def test_three_controllers_connection_schema():
-    first_controller_list = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2]
-    first_port_list = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 6, 7, 8, 9, 10, 11]
-    second_controller_list = [2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3]
-    second_port_list = [0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+    first_controller_list = [1, 1, 2, 1, 1, 2, 1, 1, 2, 1, 1, 2, 1, 1, 2, 1, 1, 2]
+    first_port_list = [0, 1, 1, 2, 3, 3, 4, 5, 5, 6, 7, 7, 8, 9, 9, 10, 11, 11]
+    second_controller_list = [2, 3, 3, 2, 3, 3, 2, 3, 3, 2, 3, 3, 2, 3, 3, 2, 3, 3]
+    second_port_list = [0, 0, 1, 2, 2, 3, 4, 4, 5, 6, 6, 7, 8, 8, 9, 10, 10, 11]
     controller_connections = [
         ControllerConnection(
             InterOpxChannel(f"con{i}", j), InterOpxChannel(f"con{k}", l)
@@ -46,117 +45,19 @@ def test_three_controllers_connection_schema():
             )
         )
     ]
-    generated_controller_connections = create_simulator_controller_connections(3, 12)
+    generated_controller_connections = create_simulator_controller_connections(3)
     assert len(controller_connections) == len(generated_controller_connections)
     for a, b in zip(controller_connections, generated_controller_connections):
         assert (a.source == b.source) & (a.target == b.target)
 
 
-def test_four_controllers_connection_schema():
-    first_controller_list = [
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        2,
-        2,
-        2,
-        2,
-        2,
-        2,
-        2,
-        2,
-        3,
-        3,
-        3,
-        3,
-    ]
-    first_port_list = [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        8,
-        9,
-        10,
-        11,
-    ]
-    second_controller_list = [
-        2,
-        2,
-        2,
-        2,
-        3,
-        3,
-        3,
-        3,
-        4,
-        4,
-        4,
-        4,
-        3,
-        3,
-        3,
-        3,
-        4,
-        4,
-        4,
-        4,
-        4,
-        4,
-        4,
-        4,
-    ]
-    second_port_list = [
-        0,
-        1,
-        2,
-        3,
-        0,
-        1,
-        2,
-        3,
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-    ]
+def test_last_two_in_a_three_controllers_connection_schema():
+    first_controller_list = [1, 1, 2, 1, 1, 2, 1, 1, 2, 1, 1, 2, 1, 1, 2, 1, 1, 2]
+    first_port_list = [0, 1, 1, 2, 3, 3, 4, 5, 5, 6, 7, 7, 8, 9, 9, 10, 11, 11]
+    second_controller_list = [2, 3, 3, 2, 3, 3, 2, 3, 3, 2, 3, 3, 2, 3, 3, 2, 3, 3]
+    second_port_list = [0, 0, 1, 2, 2, 3, 4, 4, 5, 6, 6, 7, 8, 8, 9, 10, 10, 11]
+    filtered_lists = [(item1, item2, item3, item4) for item1, item2, item3, item4 in zip(first_controller_list, first_port_list, second_controller_list, second_port_list) if item1 != 1 and item3 != 1]
+    first_controller_list, first_port_list, second_controller_list, second_port_list = zip(*filtered_lists)
     controller_connections = [
         ControllerConnection(
             InterOpxChannel(f"con{i}", j), InterOpxChannel(f"con{k}", l)
@@ -170,141 +71,19 @@ def test_four_controllers_connection_schema():
             )
         )
     ]
-    generated_controller_connections = create_simulator_controller_connections(4, 12)
+    generated_controller_connections = create_simulator_controller_connections(3, [2, 3])
     assert len(controller_connections) == len(generated_controller_connections)
     for a, b in zip(controller_connections, generated_controller_connections):
         assert (a.source == b.source) & (a.target == b.target)
 
 
-def test_five_controllers_connection_schema():
-    first_controller_list = [
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        2,
-        2,
-        2,
-        2,
-        2,
-        2,
-        2,
-        2,
-        2,
-        3,
-        3,
-        3,
-        3,
-        3,
-        3,
-        4,
-        4,
-        4,
-    ]
-    first_port_list = [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        9,
-        10,
-        11,
-    ]
-    second_controller_list = [
-        2,
-        2,
-        2,
-        3,
-        3,
-        3,
-        4,
-        4,
-        4,
-        5,
-        5,
-        5,
-        3,
-        3,
-        3,
-        4,
-        4,
-        4,
-        5,
-        5,
-        5,
-        4,
-        4,
-        4,
-        5,
-        5,
-        5,
-        5,
-        5,
-        5,
-    ]
-    second_port_list = [
-        0,
-        1,
-        2,
-        0,
-        1,
-        2,
-        0,
-        1,
-        2,
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        3,
-        4,
-        5,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-    ]
+def test_two_in_a_three_controllers_connection_schema():
+    first_controller_list = [1, 1, 2, 1, 1, 2, 1, 1, 2, 1, 1, 2, 1, 1, 2, 1, 1, 2]
+    first_port_list = [0, 1, 1, 2, 3, 3, 4, 5, 5, 6, 7, 7, 8, 9, 9, 10, 11, 11]
+    second_controller_list = [2, 3, 3, 2, 3, 3, 2, 3, 3, 2, 3, 3, 2, 3, 3, 2, 3, 3]
+    second_port_list = [0, 0, 1, 2, 2, 3, 4, 4, 5, 6, 6, 7, 8, 8, 9, 10, 10, 11]
+    filtered_lists = [(item1, item2, item3, item4) for item1, item2, item3, item4 in zip(first_controller_list, first_port_list, second_controller_list, second_port_list) if item1 != 2 and item3 != 2]
+    first_controller_list, first_port_list, second_controller_list, second_port_list = zip(*filtered_lists)
     controller_connections = [
         ControllerConnection(
             InterOpxChannel(f"con{i}", j), InterOpxChannel(f"con{k}", l)
@@ -318,363 +97,7 @@ def test_five_controllers_connection_schema():
             )
         )
     ]
-    generated_controller_connections = create_simulator_controller_connections(5, 12)
-    assert len(controller_connections) == len(generated_controller_connections)
-    for a, b in zip(controller_connections, generated_controller_connections):
-        assert (a.source == b.source) & (a.target == b.target)
-
-
-def test_six_controllers_connection_schema():
-    first_controller_list = [
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        2,
-        2,
-        2,
-        2,
-        2,
-        2,
-        2,
-        2,
-        3,
-        3,
-        3,
-        3,
-        3,
-        3,
-        4,
-        4,
-        4,
-        4,
-        5,
-        5,
-    ]
-    first_port_list = [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        6,
-        7,
-        8,
-        9,
-        8,
-        9,
-    ]
-    second_controller_list = [
-        2,
-        2,
-        3,
-        3,
-        4,
-        4,
-        5,
-        5,
-        6,
-        6,
-        3,
-        3,
-        4,
-        4,
-        5,
-        5,
-        6,
-        6,
-        4,
-        4,
-        5,
-        5,
-        6,
-        6,
-        5,
-        5,
-        6,
-        6,
-        6,
-        6,
-    ]
-    second_port_list = [
-        0,
-        1,
-        0,
-        1,
-        0,
-        1,
-        0,
-        1,
-        0,
-        1,
-        2,
-        3,
-        2,
-        3,
-        2,
-        3,
-        2,
-        3,
-        4,
-        5,
-        4,
-        5,
-        4,
-        5,
-        6,
-        7,
-        6,
-        7,
-        8,
-        9,
-    ]
-    controller_connections = [
-        ControllerConnection(
-            InterOpxChannel(f"con{i}", j), InterOpxChannel(f"con{k}", l)
-        )
-        for i, j, k, l in list(
-            zip(
-                first_controller_list,
-                first_port_list,
-                second_controller_list,
-                second_port_list,
-            )
-        )
-    ]
-    generated_controller_connections = create_simulator_controller_connections(6, 12)
-    assert len(controller_connections) == len(generated_controller_connections)
-    for a, b in zip(controller_connections, generated_controller_connections):
-        assert (a.source == b.source) & (a.target == b.target)
-
-
-def test_ten_controllers_connection_schema():
-    first_controller_list = [
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        2,
-        2,
-        2,
-        2,
-        2,
-        2,
-        2,
-        2,
-        3,
-        3,
-        3,
-        3,
-        3,
-        3,
-        3,
-        4,
-        4,
-        4,
-        4,
-        4,
-        4,
-        5,
-        5,
-        5,
-        5,
-        5,
-        6,
-        6,
-        6,
-        6,
-        7,
-        7,
-        7,
-        8,
-        8,
-        9,
-    ]
-    first_port_list = [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        4,
-        5,
-        6,
-        7,
-        8,
-        5,
-        6,
-        7,
-        8,
-        6,
-        7,
-        8,
-        7,
-        8,
-        8,
-    ]
-    second_controller_list = [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        6,
-        7,
-        8,
-        9,
-        10,
-        7,
-        8,
-        9,
-        10,
-        8,
-        9,
-        10,
-        9,
-        10,
-        10,
-    ]
-    second_port_list = [
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        2,
-        2,
-        2,
-        2,
-        2,
-        2,
-        2,
-        3,
-        3,
-        3,
-        3,
-        3,
-        3,
-        4,
-        4,
-        4,
-        4,
-        4,
-        5,
-        5,
-        5,
-        5,
-        6,
-        6,
-        6,
-        7,
-        7,
-        8,
-    ]
-    controller_connections = [
-        ControllerConnection(
-            InterOpxChannel(f"con{i}", j), InterOpxChannel(f"con{k}", l)
-        )
-        for i, j, k, l in list(
-            zip(
-                first_controller_list,
-                first_port_list,
-                second_controller_list,
-                second_port_list,
-            )
-        )
-    ]
-    generated_controller_connections = create_simulator_controller_connections(10, 12)
+    generated_controller_connections = create_simulator_controller_connections(3, [1, 3])
     assert len(controller_connections) == len(generated_controller_connections)
     for a, b in zip(controller_connections, generated_controller_connections):
         assert (a.source == b.source) & (a.target == b.target)


### PR DESCRIPTION
This creates the controller connections in a much nicer way, which also matches the documenation.
I think we can completely remove the `old_method`.
It also adds an option to use a subset of the controllers, but currently only remove those from the end (so if you have a 6 OPX setup, you can use 1-4, but not 3-6), but that can be edited.
WDYT?