### PR TITLE
Feat: Add `node.json` to data handler for metadata

### DIFF
--- a/qualang_tools/results/README.md
+++ b/qualang_tools/results/README.md
@@ -200,7 +200,7 @@ print(data_folder)
 # C:/data/2024-02-24/#152_T1_measurement_095214
 # This assumes the save was performed at 2024-02-24 at 09:52:14
 ```
-After calling `data_handler.save_data()`, three files are created in `data_folder`:
+After calling `data_handler.save_data()`, four files are created in `data_folder`:
 - `T1_figure.png`
 - `arrays.npz` containing all the numpy arrays
 - `data.json` which contains:  
@@ -211,6 +211,7 @@ After calling `data_handler.save_data()`, three files are created in `data_folde
         "IQ_array": "./arrays.npz#IQ_array"
     }
     ```
+- `node.json` which contains all metadata related to this save.
 
 ### Creating a data folder
 A data folder can be created in two ways:

--- a/qualang_tools/results/data_handler/data_folder_tools.py
+++ b/qualang_tools/results/data_handler/data_folder_tools.py
@@ -1,4 +1,8 @@
-"""Tools for handling data folders."""
+"""Tools for handling data folders.
+
+This module provides functions for handling data folders, including extracting properties from data folders,
+finding the latest data folder, generating relative folder names, and creating new data folders.
+"""
 
 from pathlib import Path
 from typing import Dict, Union, Optional
@@ -158,8 +162,17 @@ def get_latest_data_folder(
         return None
 
 
-def generate_data_folder_relative_pathname(idx: int, name: str, created_at: datetime, folder_pattern: str) -> str:
-    """Generate the relative name of a data folder."""
+def generate_data_folder_relative_pathname(
+    idx: int, name: str, created_at: datetime, folder_pattern: str = DEFAULT_FOLDER_PATTERN
+) -> str:
+    """Generate the relative data folder name using a folder pattern.
+
+    :param idx: The index of the data folder.
+    :param name: The name of the data folder.
+    :param created_at: The datetime to use for the folder name.
+    :param folder_pattern: The pattern of the data folder, e.g. "%Y-%m-%d/#{idx}_{name}_%H%M%S".
+    :return: The relative folder name
+    """
     relative_folder_name = folder_pattern.format(idx=idx, name=name)
     relative_folder_name = created_at.strftime(relative_folder_name)
     return relative_folder_name
@@ -183,6 +196,13 @@ def create_data_folder(
     :param folder_pattern: The pattern of the data folder, e.g. "%Y-%m-%d/#{idx}_{name}_%H%M%S".
     :param created_at: The datetime to use for the folder name.
     :param create: Whether to create the folder or not.
+    :return: A dictionary with the properties of the new data folder.
+    Dictionary keys:
+        - idx: The index of the data folder.
+        - name: The name of the data folder.
+        - path: The absolute path of the data folder.
+        - relative_path: The relative path of the data folder w.r.t the root_data_folder.
+        - created_at: The datetime the data folder was created.
     """
     if isinstance(root_data_folder, str):
         root_data_folder = Path(root_data_folder)

--- a/qualang_tools/results/data_handler/data_folder_tools.py
+++ b/qualang_tools/results/data_handler/data_folder_tools.py
@@ -158,7 +158,8 @@ def get_latest_data_folder(
         return None
 
 
-def generate_data_folder_relative_name(idx: int, name: str, created_at: datetime, folder_pattern: str) -> str:
+def generate_data_folder_relative_pathname(idx: int, name: str, created_at: datetime, folder_pattern: str) -> str:
+    """Generate the relative name of a data folder."""
     relative_folder_name = folder_pattern.format(idx=idx, name=name)
     relative_folder_name = created_at.strftime(relative_folder_name)
     return relative_folder_name
@@ -202,7 +203,7 @@ def create_data_folder(
         else:
             idx = latest_folder_properties["idx"] + 1
 
-    relative_folder_name = generate_data_folder_relative_name(
+    relative_folder_name = generate_data_folder_relative_pathname(
         idx=idx, name=name, created_at=created_at, folder_pattern=folder_pattern
     )
 

--- a/qualang_tools/results/data_handler/data_folder_tools.py
+++ b/qualang_tools/results/data_handler/data_folder_tools.py
@@ -158,9 +158,9 @@ def get_latest_data_folder(
         return None
 
 
-def generate_data_folder_relative_name(idx: int, name: str, use_datetime: datetime, folder_pattern: str) -> str:
+def generate_data_folder_relative_name(idx: int, name: str, created_at: datetime, folder_pattern: str) -> str:
     relative_folder_name = folder_pattern.format(idx=idx, name=name)
-    relative_folder_name = use_datetime.strftime(relative_folder_name)
+    relative_folder_name = created_at.strftime(relative_folder_name)
     return relative_folder_name
 
 
@@ -169,7 +169,7 @@ def create_data_folder(
     name: str,
     idx: Optional[int] = None,
     folder_pattern: str = DEFAULT_FOLDER_PATTERN,
-    use_datetime: Optional[datetime] = None,
+    created_at: Optional[datetime] = None,
     create: bool = True,
 ) -> Dict[str, Union[str, int, Path]]:
     """Create a new data folder in a given root data folder.
@@ -180,7 +180,7 @@ def create_data_folder(
     :param name: The name of the new data folder.
     :param idx: The index of the new data folder. If not provided, the index is determined automatically.
     :param folder_pattern: The pattern of the data folder, e.g. "%Y-%m-%d/#{idx}_{name}_%H%M%S".
-    :param use_datetime: The datetime to use for the folder name.
+    :param created_at: The datetime to use for the folder name.
     :param create: Whether to create the folder or not.
     """
     if isinstance(root_data_folder, str):
@@ -189,8 +189,8 @@ def create_data_folder(
     if not root_data_folder.exists():
         raise NotADirectoryError(f"Root data folder {root_data_folder} does not exist.")
 
-    if use_datetime is None:
-        use_datetime = datetime.now()
+    if created_at is None:
+        created_at = datetime.now()
 
     if idx is None:
         # Determine the latest folder index and increment by one
@@ -203,7 +203,7 @@ def create_data_folder(
             idx = latest_folder_properties["idx"] + 1
 
     relative_folder_name = generate_data_folder_relative_name(
-        idx=idx, name=name, use_datetime=use_datetime, folder_pattern=folder_pattern
+        idx=idx, name=name, created_at=created_at, folder_pattern=folder_pattern
     )
 
     data_folder = root_data_folder / relative_folder_name
@@ -214,7 +214,7 @@ def create_data_folder(
             "name": name,
             "path": data_folder,
             "relative_path": data_folder.relative_to(root_data_folder),
-            "created_at": use_datetime,
+            "created_at": created_at,
         }
 
     if data_folder.exists():

--- a/qualang_tools/results/data_handler/data_folder_tools.py
+++ b/qualang_tools/results/data_handler/data_folder_tools.py
@@ -57,7 +57,7 @@ def extract_data_folder_properties(
     if root_data_folder is not None:
         folder_path_str = str(data_folder.relative_to(root_data_folder))
     else:
-        folder_path_str = data_folder.name
+        folder_path_str = str(data_folder)
 
     folder_path_str = folder_path_str.replace("\\", "/")
 
@@ -67,7 +67,9 @@ def extract_data_folder_properties(
     properties = regex_match.groupdict()
     properties = {key: int(value) if value.isdigit() else value for key, value in properties.items()}
 
-    datetime_properties = {key: properties.pop(key) for key in ["year", "month", "day", "hour", "minute", "second"]}
+    datetime_properties = {
+        key: properties.pop(key) for key in ["year", "month", "day", "hour", "minute", "second"] if key in properties
+    }
     properties["created_at"] = datetime(**datetime_properties)
 
     properties["path"] = data_folder
@@ -156,6 +158,12 @@ def get_latest_data_folder(
         return None
 
 
+def generate_data_folder_relative_name(idx: int, name: str, use_datetime: datetime, folder_pattern: str) -> str:
+    relative_folder_name = folder_pattern.format(idx=idx, name=name)
+    relative_folder_name = use_datetime.strftime(relative_folder_name)
+    return relative_folder_name
+
+
 def create_data_folder(
     root_data_folder: Path,
     name: str,
@@ -194,8 +202,9 @@ def create_data_folder(
         else:
             idx = latest_folder_properties["idx"] + 1
 
-    relative_folder_name = folder_pattern.format(idx=idx, name=name)
-    relative_folder_name = use_datetime.strftime(relative_folder_name)
+    relative_folder_name = generate_data_folder_relative_name(
+        idx=idx, name=name, use_datetime=use_datetime, folder_pattern=folder_pattern
+    )
 
     data_folder = root_data_folder / relative_folder_name
 

--- a/qualang_tools/results/data_handler/data_handler.py
+++ b/qualang_tools/results/data_handler/data_handler.py
@@ -9,7 +9,7 @@ from .data_processors import DEFAULT_DATA_PROCESSORS, DataProcessor
 from .data_folder_tools import (
     DEFAULT_FOLDER_PATTERN,
     create_data_folder,
-    generate_data_folder_relative_name,
+    generate_data_folder_relative_pathname,
     get_latest_data_folder,
 )
 
@@ -158,7 +158,7 @@ class DataHandler:
         metadata = metadata.copy() if metadata is not None else {}
         metadata["name"] = self.name
 
-        metadata["data_path"] = generate_data_folder_relative_name(
+        metadata["data_path"] = generate_data_folder_relative_pathname(
             idx=idx, name=self.name, created_at=created_at, folder_pattern=self.folder_pattern
         )
 

--- a/qualang_tools/results/data_handler/data_handler.py
+++ b/qualang_tools/results/data_handler/data_handler.py
@@ -143,6 +143,18 @@ class DataHandler:
         created_at: Optional[datetime] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
+        """Generate the contents of the node.json file, which contains all node-related metadata.
+
+        :param idx: The index of the data folder.
+        :type idx: int, optional
+        :param created_at: The datetime to be used in the folder name.
+        :type created_at: datetime, optional
+        :param metadata: The user-specified metadata associated with the data. "name" and "data_path" are added to
+        this metadata.
+        :type metadata: any, optional
+        :return: The contents of the node.json file.
+        :rtype: dict
+        """
         # Check if an empty folder has been created, if so, use the idx and datetime from the folder
         if self.path_properties is not None and idx is None and created_at is None:
             if not (self.path / NODE_FILENAME).exists():

--- a/qualang_tools/results/data_handler/data_handler.py
+++ b/qualang_tools/results/data_handler/data_handler.py
@@ -17,7 +17,7 @@ def save_data(
     data: Dict[str, Any],
     metadata: Optional[Dict[str, Any]] = None,
     data_filename: str = "data.json",
-    metadata_filename: str = "metadata.json",
+    metadata_filename: str = "node.json",
     data_processors: Sequence[DataProcessor] = (),
 ) -> Path:
     """
@@ -102,7 +102,7 @@ class DataHandler:
     root_data_folder: Path = None
     folder_pattern: str = DEFAULT_FOLDER_PATTERN
     data_filename: str = "data.json"
-    metadata_filename: str = "metadata.json"
+    metadata_filename: str = "node.json"
     additional_files: Dict[str, str] = {}
 
     def __init__(
@@ -118,7 +118,9 @@ class DataHandler:
         if data_processors is not None:
             self.data_processors = data_processors
         else:
-            self.data_processors = [processor() for processor in self.default_data_processors]
+            self.data_processors = [
+                processor() for processor in self.default_data_processors
+            ]
 
         if root_data_folder is not None:
             self.root_data_folder = root_data_folder
@@ -243,7 +245,10 @@ class DataHandler:
 
         for source_name, destination_name in self.additional_files.items():
             if not Path(source_name).exists():
-                warnings.warn(f"Additional file {source_name} does not exist, not copying", UserWarning)
+                warnings.warn(
+                    f"Additional file {source_name} does not exist, not copying",
+                    UserWarning,
+                )
                 continue
 
             shutil.copy(source_name, data_folder / destination_name)

--- a/qualang_tools/results/data_handler/data_processors.py
+++ b/qualang_tools/results/data_handler/data_processors.py
@@ -111,7 +111,8 @@ class NumpyArraySaver(DataProcessor):
     def post_process(self, data_folder: Path):
         if self.merge_arrays:
             arrays = {str(path): arr for path, arr in self.data_arrays.items()}
-            np.savez(data_folder / self.merged_array_name, **arrays)
+            if arrays:
+                np.savez(data_folder / self.merged_array_name, **arrays)
         else:
             for path, arr in self.data_arrays.items():
                 np.save(data_folder / path.with_suffix(".npy"), arr)

--- a/tests/data_handler/test_create_data_folder.py
+++ b/tests/data_handler/test_create_data_folder.py
@@ -13,7 +13,7 @@ def test_create_data_folder(tmp_path):
 
 
 def test_create_data_folder_empty(tmp_path):
-    now = datetime.now()
+    now = datetime.now().replace(microsecond=0)
 
     properties = create_data_folder(tmp_path, name="my_test", use_datetime=now)
 
@@ -23,12 +23,7 @@ def test_create_data_folder_empty(tmp_path):
     properties_expected = {
         "idx": 1,
         "name": "my_test",
-        "year": now.year,
-        "month": now.month,
-        "day": now.day,
-        "hour": now.hour,
-        "minute": now.minute,
-        "second": now.second,
+        "created_at": now,
         "path": tmp_path / path,
         "relative_path": Path(path),
     }
@@ -37,7 +32,7 @@ def test_create_data_folder_empty(tmp_path):
 
 
 def test_create_successive_data_folder(tmp_path):
-    now = datetime.now()
+    now = datetime.now().replace(microsecond=0)
 
     properties = create_data_folder(tmp_path, name="my_test", use_datetime=now)
     path = DEFAULT_FOLDER_PATTERN.format(idx=1, name="my_test")
@@ -46,12 +41,7 @@ def test_create_successive_data_folder(tmp_path):
     properties_expected = {
         "idx": 1,
         "name": "my_test",
-        "year": now.year,
-        "month": now.month,
-        "day": now.day,
-        "hour": now.hour,
-        "minute": now.minute,
-        "second": now.second,
+        "created_at": now,
         "path": tmp_path / path,
         "relative_path": Path(path),
     }
@@ -66,12 +56,7 @@ def test_create_successive_data_folder(tmp_path):
     properties_expected = {
         "idx": 2,
         "name": "my_test",
-        "year": now.year,
-        "month": now.month,
-        "day": now.day,
-        "hour": now.hour,
-        "minute": now.minute,
-        "second": now.second,
+        "created_at": now,
         "path": tmp_path / path,
         "relative_path": Path(path),
     }
@@ -94,7 +79,7 @@ def test_performance_get_idxs(tmp_path):
 
 
 def test_create_data_folder_without_creating(tmp_path):
-    now = datetime.now()
+    now = datetime.now().replace(microsecond=0)
 
     for k in range(3):
         properties = create_data_folder(tmp_path, name="my_test", use_datetime=now, create=False)
@@ -105,12 +90,7 @@ def test_create_data_folder_without_creating(tmp_path):
         properties_expected = {
             "idx": 1,
             "name": "my_test",
-            "year": now.year,
-            "month": now.month,
-            "day": now.day,
-            "hour": now.hour,
-            "minute": now.minute,
-            "second": now.second,
+            "created_at": now,
             "path": tmp_path / path,
             "relative_path": path,
         }

--- a/tests/data_handler/test_create_data_folder.py
+++ b/tests/data_handler/test_create_data_folder.py
@@ -15,7 +15,7 @@ def test_create_data_folder(tmp_path):
 def test_create_data_folder_empty(tmp_path):
     now = datetime.now().replace(microsecond=0)
 
-    properties = create_data_folder(tmp_path, name="my_test", use_datetime=now)
+    properties = create_data_folder(tmp_path, name="my_test", created_at=now)
 
     path = DEFAULT_FOLDER_PATTERN.format(idx=1, name="my_test")
     path = now.strftime(path)
@@ -34,7 +34,7 @@ def test_create_data_folder_empty(tmp_path):
 def test_create_successive_data_folder(tmp_path):
     now = datetime.now().replace(microsecond=0)
 
-    properties = create_data_folder(tmp_path, name="my_test", use_datetime=now)
+    properties = create_data_folder(tmp_path, name="my_test", created_at=now)
     path = DEFAULT_FOLDER_PATTERN.format(idx=1, name="my_test")
     path = now.strftime(path)
 
@@ -48,7 +48,7 @@ def test_create_successive_data_folder(tmp_path):
 
     assert properties == properties_expected
 
-    properties = create_data_folder(tmp_path, name="my_test", use_datetime=now)
+    properties = create_data_folder(tmp_path, name="my_test", created_at=now)
 
     path = DEFAULT_FOLDER_PATTERN.format(idx=2, name="my_test")
     path = now.strftime(path)
@@ -72,7 +72,7 @@ def test_performance_get_idxs(tmp_path):
     now = datetime.now()
 
     for k in range(1, 110):
-        properties = create_data_folder(tmp_path, name="my_test", use_datetime=now)
+        properties = create_data_folder(tmp_path, name="my_test", created_at=now)
         properties_latest = get_latest_data_folder(tmp_path)
 
         assert properties["idx"] == properties_latest["idx"] == k
@@ -82,7 +82,7 @@ def test_create_data_folder_without_creating(tmp_path):
     now = datetime.now().replace(microsecond=0)
 
     for k in range(3):
-        properties = create_data_folder(tmp_path, name="my_test", use_datetime=now, create=False)
+        properties = create_data_folder(tmp_path, name="my_test", created_at=now, create=False)
         path = DEFAULT_FOLDER_PATTERN.format(idx=1, name="my_test")
         path = now.strftime(path)
         path = Path(path)

--- a/tests/data_handler/test_data_handler.py
+++ b/tests/data_handler/test_data_handler.py
@@ -15,7 +15,7 @@ def test_data_handler_basic(tmp_path):
 
     now = datetime.now()
 
-    data_handler.save_data(data, "my_data", use_datetime=now)
+    data_handler.save_data(data, "my_data", created_at=now)
 
     expected_data_folder = DEFAULT_FOLDER_PATTERN.format(name="my_data", idx=1)
     expected_data_folder = now.strftime(expected_data_folder)
@@ -35,7 +35,7 @@ def test_data_handler_metadata(tmp_path):
 
     now = datetime.now()
 
-    data_handler.save_data(data, "my_data", metadata=metadata, use_datetime=now)
+    data_handler.save_data(data, "my_data", metadata=metadata, created_at=now)
 
     expected_data_folder = DEFAULT_FOLDER_PATTERN.format(name="my_data", idx=1)
     expected_data_folder = now.strftime(expected_data_folder)
@@ -69,7 +69,7 @@ def test_data_handler_custom_processors(tmp_path):
 
     now = datetime.now()
 
-    data_handler.save_data(data, "my_data", use_datetime=now)
+    data_handler.save_data(data, "my_data", created_at=now)
 
     expected_data_folder = DEFAULT_FOLDER_PATTERN.format(name="my_data", idx=1)
     expected_data_folder = now.strftime(expected_data_folder)
@@ -92,7 +92,7 @@ def test_data_handler_matplotlib_processor(tmp_path):
 
     now = datetime.now()
 
-    data_handler.save_data(data, "my_data", use_datetime=now)
+    data_handler.save_data(data, "my_data", created_at=now)
 
     expected_data_folder = DEFAULT_FOLDER_PATTERN.format(name="my_data", idx=1)
     expected_data_folder = now.strftime(expected_data_folder)
@@ -113,7 +113,7 @@ def test_data_handler_no_name_create_folder(tmp_path):
     now = datetime.now()
 
     with pytest.raises(ValueError):
-        data_handler.create_data_folder(use_datetime=now)
+        data_handler.create_data_folder(created_at=now)
 
 
 def test_data_handler_initialized_name_create_folder(tmp_path):
@@ -122,7 +122,7 @@ def test_data_handler_initialized_name_create_folder(tmp_path):
 
     now = datetime.now()
 
-    data_handler.create_data_folder(use_datetime=now)
+    data_handler.create_data_folder(created_at=now)
 
     expected_data_folder = DEFAULT_FOLDER_PATTERN.format(name="my_data", idx=1)
     expected_data_folder = now.strftime(expected_data_folder)
@@ -136,7 +136,7 @@ def test_data_handler_overwrite_initialized_name_create_folder(tmp_path):
 
     now = datetime.now()
 
-    data_handler.create_data_folder(name="my_new_data", use_datetime=now)
+    data_handler.create_data_folder(name="my_new_data", created_at=now)
     assert data_handler.name == "my_new_data"
 
     expected_data_folder = DEFAULT_FOLDER_PATTERN.format(name="my_new_data", idx=1)
@@ -159,7 +159,7 @@ def test_data_handler_initialized_name_save_data(tmp_path):
 
     now = datetime.now()
 
-    data_handler.save_data({"a": 1, "b": 2, "c": 3}, use_datetime=now)
+    data_handler.save_data({"a": 1, "b": 2, "c": 3}, created_at=now)
 
     expected_data_folder = DEFAULT_FOLDER_PATTERN.format(name="my_data", idx=1)
     expected_data_folder = now.strftime(expected_data_folder)
@@ -173,7 +173,7 @@ def test_data_handler_overwrite_initialized_name_save_data(tmp_path):
 
     now = datetime.now()
 
-    data_handler.save_data({"a": 1, "b": 2, "c": 3}, name="my_new_data", use_datetime=now)
+    data_handler.save_data({"a": 1, "b": 2, "c": 3}, name="my_new_data", created_at=now)
     assert data_handler.name == "my_new_data"
 
     expected_data_folder = DEFAULT_FOLDER_PATTERN.format(name="my_new_data", idx=1)
@@ -215,14 +215,14 @@ def test_data_handler_multiple_saves(tmp_path):
     data = {"a": 1, "b": 2, "c": 3}
     now = datetime.now()
 
-    data_handler.save_data(data, "my_data", use_datetime=now)
+    data_handler.save_data(data, "my_data", created_at=now)
 
     expected_data_folder = DEFAULT_FOLDER_PATTERN.format(name="my_data", idx=1)
     expected_data_folder = now.strftime(expected_data_folder)
 
     assert data_handler.path == (tmp_path / expected_data_folder)
 
-    data_handler.save_data(data, "my_data", use_datetime=now)
+    data_handler.save_data(data, "my_data", created_at=now)
 
     expected_data_folder = DEFAULT_FOLDER_PATTERN.format(name="my_data", idx=2)
     expected_data_folder = now.strftime(expected_data_folder)

--- a/tests/data_handler/test_data_handler.py
+++ b/tests/data_handler/test_data_handler.py
@@ -41,13 +41,20 @@ def test_data_handler_metadata(tmp_path):
     expected_data_folder = now.strftime(expected_data_folder)
 
     assert (tmp_path / expected_data_folder / "data.json").exists()
-    assert (tmp_path / expected_data_folder / "metadata.json").exists()
+    assert (tmp_path / expected_data_folder / "node.json").exists()
 
     file_data = json.loads((tmp_path / expected_data_folder / "data.json").read_text())
-    file_metadata = json.loads((tmp_path / expected_data_folder / "metadata.json").read_text())
+    file_node = json.loads((tmp_path / expected_data_folder / "node.json").read_text())
 
     assert file_data == data
-    assert file_metadata == metadata
+    expected_file_node = {
+        "created_at": now.replace(microsecond=0).astimezone().isoformat(),
+        "metadata": {**metadata, "name": "my_data", "data_path": expected_data_folder},
+        "id": 1,
+        "data": {},
+        "parents": [],
+    }
+    assert file_node == expected_file_node
 
 
 def test_data_handler_custom_processors(tmp_path):

--- a/tests/data_handler/test_data_handler.py
+++ b/tests/data_handler/test_data_handler.py
@@ -40,6 +40,9 @@ def test_data_handler_metadata(tmp_path):
     expected_data_folder = DEFAULT_FOLDER_PATTERN.format(name="my_data", idx=1)
     expected_data_folder = now.strftime(expected_data_folder)
 
+    elems = list((tmp_path / expected_data_folder).iterdir())
+    assert set([elem.name for elem in elems]) == {"data.json", "node.json"}
+
     assert (tmp_path / expected_data_folder / "data.json").exists()
     assert (tmp_path / expected_data_folder / "node.json").exists()
 

--- a/tests/data_handler/test_data_handler_generate_node.py
+++ b/tests/data_handler/test_data_handler_generate_node.py
@@ -1,0 +1,73 @@
+from datetime import datetime
+from typing import Dict, Any, Optional
+import pytest
+
+from qualang_tools.results.data_handler.data_handler import DataHandler
+
+
+def test_generate_node_contents_empty_folder(tmp_path):
+    created_at = datetime(2023, 2, 1, 12, 34, 56)
+    data_handler = DataHandler(root_data_folder=tmp_path, name="msmt_name")
+
+    node_contents = data_handler.generate_node_contents(created_at=created_at)
+
+    assert node_contents == {
+        "created_at": created_at.astimezone().replace(microsecond=0).isoformat(),
+        "metadata": {"name": "msmt_name", "data_path": f"2023-02-01/#{idx}_msmt_name_123456"},
+        "data": {},
+        "id": 1,
+        "parents": [],
+    }
+
+
+def test_generate_node_contents_with_idx_and_created_at(tmp_path):
+    created_at = datetime(2023, 2, 1, 12, 34, 56)
+    data_handler = DataHandler(root_data_folder=tmp_path)
+
+    idx = 2
+    node_contents = data_handler.generate_node_contents(idx=idx, created_at=created_at)
+
+    assert node_contents == {
+        "created_at": created_at.astimezone().replace(microsecond=0).isoformat(),
+        "metadata": {"name": None, "data_path": f"2023-02-01/#{idx}_None_123456"},
+        "data": {},
+        "id": idx,
+        "parents": [1],
+    }
+
+
+def test_generate_node_contents_with_all_parameters(tmp_path):
+    created_at = datetime(2023, 2, 1, 12, 34, 56)
+    data_handler = DataHandler(root_data_folder=tmp_path)
+
+    idx = 2
+    metadata = {"key": "value"}
+    node_contents = data_handler.generate_node_contents(idx=idx, created_at=created_at, metadata=metadata)
+
+    assert node_contents == {
+        "created_at": created_at.astimezone().replace(microsecond=0).isoformat(),
+        "metadata": {"name": None, "data_path": f"2023-02-01/#{idx}_None_123456", "key": "value"},
+        "data": {},
+        "id": idx,
+        "parents": [1],
+    }
+
+
+def test_generate_node_contents_with_existing_folder_properties(tmp_path):
+    now = datetime(2023, 2, 1, 12, 34, 56)
+    data_handler = DataHandler(root_data_folder=tmp_path, name="msmt_name")
+
+    # Create an empty folder with properties
+    path = tmp_path / "2023-02-01" / "#1_msmt_name_123456"
+    path.mkdir(parents=True)
+    (path / "node.json").write_text('{"idx": 1, "created_at": "2022-01-01T00:00:00"}')
+
+    node_contents = data_handler.generate_node_contents(created_at=now)
+
+    assert node_contents == {
+        "created_at": now.astimezone().replace(microsecond=0).isoformat(),
+        "metadata": {"name": "msmt_name", "data_path": f"2023-02-01/#2_msmt_name_123456"},
+        "data": {},
+        "id": 2,
+        "parents": [1],
+    }

--- a/tests/data_handler/test_data_handler_generate_node.py
+++ b/tests/data_handler/test_data_handler_generate_node.py
@@ -13,7 +13,7 @@ def test_generate_node_contents_empty_folder(tmp_path):
 
     assert node_contents == {
         "created_at": created_at.astimezone().replace(microsecond=0).isoformat(),
-        "metadata": {"name": "msmt_name", "data_path": f"2023-02-01/#{idx}_msmt_name_123456"},
+        "metadata": {"name": "msmt_name", "data_path": f"2023-02-01/#1_msmt_name_123456"},
         "data": {},
         "id": 1,
         "parents": [],

--- a/tests/data_handler/test_extract_data_folder_properties.py
+++ b/tests/data_handler/test_extract_data_folder_properties.py
@@ -1,21 +1,20 @@
-import pytest
+from datetime import datetime
 from pathlib import Path
 from qualang_tools.results.data_handler.data_folder_tools import extract_data_folder_properties
 
 
 def test_extract_data_folder_properties():
-    properties = extract_data_folder_properties(Path("#123_test_123456"), "#{idx}_{name}_%H%M%S")
+    properties = extract_data_folder_properties(Path("2023-12-07/#123_test_123456"), "%Y-%m-%d/#{idx}_{name}_%H%M%S")
     expected_properties = {
+        "created_at": datetime(year=2023, month=12, day=7, hour=12, minute=34, second=56),
+        "path": Path("2023-12-07/#123_test_123456"),
         "idx": 123,
         "name": "test",
-        "hour": 12,
-        "minute": 34,
-        "second": 56,
-        "path": Path("#123_test_123456"),
     }
     assert properties == expected_properties
 
-    properties = extract_data_folder_properties(Path("#123_my_test_123456"), "#{idx}_{name}_%H%M%S")
+    properties = extract_data_folder_properties(Path("2023-12-07/#124_my_test_123456"), "%Y-%m-%d/#{idx}_{name}_%H%M%S")
     expected_properties["name"] = "my_test"
-    expected_properties["path"] = Path("#123_my_test_123456")
+    expected_properties["path"] = Path("2023-12-07/#124_my_test_123456")
+    expected_properties["idx"] = 124
     assert properties == expected_properties

--- a/tests/data_handler/test_generate_data_folder_relative_pathname.py
+++ b/tests/data_handler/test_generate_data_folder_relative_pathname.py
@@ -1,0 +1,9 @@
+from datetime import datetime
+from qualang_tools.results.data_handler.data_folder_tools import generate_data_folder_relative_pathname
+
+
+def test_generate_data_folder_relative_pathname():
+    now = datetime(year=2023, month=2, day=1, hour=12, minute=34, second=56)
+    pathname = generate_data_folder_relative_pathname(name="my_data", idx=1, created_at=now)
+
+    assert pathname == "2023-02-01/#1_my_data_123456"

--- a/tests/data_handler/test_get_latest_data_folder.py
+++ b/tests/data_handler/test_get_latest_data_folder.py
@@ -20,12 +20,7 @@ def test_get_latest_data_folder_default_structure(tmp_path):
     expected_properties = {
         "idx": 123,
         "name": "test",
-        "year": 2021,
-        "month": 1,
-        "day": 5,
-        "hour": 12,
-        "minute": 34,
-        "second": 56,
+        "created_at": datetime(year=2021, month=1, day=5, hour=12, minute=34, second=56),
         "path": date_folder / "#123_test_123456",
         "relative_path": Path(f"{date_folder.name}/#123_test_123456"),
     }
@@ -43,12 +38,7 @@ def test_get_latest_data_folder_two_items(tmp_path):
     expected_properties = {
         "idx": 124,
         "name": "test",
-        "year": 2021,
-        "month": 1,
-        "day": 5,
-        "hour": 12,
-        "minute": 34,
-        "second": 57,
+        "created_at": datetime(year=2021, month=1, day=5, hour=12, minute=34, second=57),
         "path": date_folder / "#124_test_123457",
         "relative_path": Path(f"{date_folder.name}/#124_test_123457"),
     }
@@ -69,12 +59,7 @@ def test_get_latest_data_folder_two_items_different_date(tmp_path):
     expected_properties = {
         "idx": 124,
         "name": "test",
-        "year": 2021,
-        "month": 1,
-        "day": 6,
-        "hour": 12,
-        "minute": 34,
-        "second": 57,
+        "created_at": datetime(year=2021, month=1, day=6, hour=12, minute=34, second=57),
         "path": date_folder / "#124_test_123457",
         "relative_path": Path(f"{date_folder.name}/#124_test_123457"),
     }
@@ -94,12 +79,7 @@ def test_get_latest_data_folder_different_date_empty_last_folder(tmp_path):
     expected_properties = {
         "idx": 123,
         "name": "test",
-        "year": 2021,
-        "month": 1,
-        "day": 5,
-        "hour": 12,
-        "minute": 34,
-        "second": 56,
+        "created_at": datetime(year=2021, month=1, day=5, hour=12, minute=34, second=56),
         "path": tmp_path / "2021-01-05/#123_test_123456",
         "relative_path": Path("2021-01-05/#123_test_123456"),
     }
@@ -118,12 +98,7 @@ def test_get_latest_data_folder_switched_idxs(tmp_path):
     expected_properties = {
         "idx": 123,
         "name": "test",
-        "year": 2021,
-        "month": 1,
-        "day": 6,
-        "hour": 12,
-        "minute": 34,
-        "second": 57,
+        "created_at": datetime(year=2021, month=1, day=6, hour=12, minute=34, second=57),
         "path": date_folder / "#123_test_123457",
         "relative_path": Path(f"{date_folder.name}/#123_test_123457"),
     }

--- a/tests/data_handler/test_matplotlib_plot_saver.py
+++ b/tests/data_handler/test_matplotlib_plot_saver.py
@@ -30,9 +30,9 @@ def test_save_plot_basic(tmp_path, fig):
 
     assert len(list(tmp_path.iterdir())) == 0
 
-    save_data(data_folder=tmp_path, data=data, data_processors=[MatplotlibPlotSaver()])
+    save_data(data_folder=tmp_path, data=data, node_contents={}, data_processors=[MatplotlibPlotSaver()])
 
-    assert set(f.name for f in tmp_path.iterdir()) == set(["data.json", "c.png"])
+    assert set(f.name for f in tmp_path.iterdir()) == set(["data.json", "node.json", "c.png"])
 
     file_data = json.loads((tmp_path / "data.json").read_text())
 

--- a/tests/data_handler/test_save_data.py
+++ b/tests/data_handler/test_save_data.py
@@ -4,9 +4,9 @@ from qualang_tools.results.data_handler.data_handler import save_data
 
 def test_save_data_basic(tmp_path):
     data = {"a": 1, "b": 2, "c": 3}
-    save_data(data_folder=tmp_path, data=data)
+    save_data(data_folder=tmp_path, data=data, node_contents={})
 
-    assert list(f.name for f in tmp_path.iterdir()) == ["data.json"]
+    assert list(f.name for f in tmp_path.iterdir()) == ["data.json", "node.json"]
 
     file_data = json.loads((tmp_path / "data.json").read_text())
 
@@ -16,11 +16,11 @@ def test_save_data_basic(tmp_path):
 def test_save_data_metadata(tmp_path):
     data = {"a": 1, "b": 2, "c": 3}
     metadata = {"meta": "data"}
-    save_data(data_folder=tmp_path, data=data, metadata=metadata)
-    assert set(f.name for f in tmp_path.iterdir()) == set(["data.json", "metadata.json"])
+    save_data(data_folder=tmp_path, data=data, metadata=metadata, node_contents={})
+    assert set(f.name for f in tmp_path.iterdir()) == set(["data.json", "node.json"])
 
     file_data = json.loads((tmp_path / "data.json").read_text())
-    file_metadata = json.loads((tmp_path / "metadata.json").read_text())
+    file_node = json.loads((tmp_path / "node.json").read_text())
 
     assert file_data == data
-    assert file_metadata == metadata
+    assert file_node == {"metadata": metadata}

--- a/tests/data_handler/test_save_data.py
+++ b/tests/data_handler/test_save_data.py
@@ -6,7 +6,7 @@ def test_save_data_basic(tmp_path):
     data = {"a": 1, "b": 2, "c": 3}
     save_data(data_folder=tmp_path, data=data, node_contents={})
 
-    assert list(f.name for f in tmp_path.iterdir()) == ["data.json", "node.json"]
+    assert set(f.name for f in tmp_path.iterdir()) == set(["data.json", "node.json"])
 
     file_data = json.loads((tmp_path / "data.json").read_text())
 


### PR DESCRIPTION
For details see https://quantum-machines.atlassian.net/browse/QUAL-16

When performing a save, a separate file `node.json` should be always included. This file should
- Contain user-specified metadata (through `data_handler.save()`)
  - Some of this metadata `"name"` and `"data_path"`, maybe later others, are also passed on automatically.
  - I think it's fine that these metadata groupings (user-defined and fixed) are combined
- `"data"` contains either quam itself, or file links to quam

The structure of `node.json` should be:
```JSON
{
  "created_at": "2024-03-13 17:30:39 UTC+01:00", # Or whatever ISO 8601 suggests
  "metadata": {
    "name": "node_name",
    "data_path": "2024-03-13/#144_node_name_173039"
    # Other metadata entries
  },
  "data": {
    "quam": "./state.json"
  },
  "parents": [
    143
  ],
  "id": 144,
}
```