### PR TITLE
fix: only add xarray data processor if installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Fixed
 - Only load DataHandler XarrayDataProcessor if xarray can be imported
+- Fix bug with the data folder path.
 
 ## [0.17.0] - 2024-04-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+### Fixed
+- Only load DataHandler XarrayDataProcessor if xarray can be imported
 
 ## [0.17.0] - 2024-04-18
 ### Added

--- a/qualang_tools/results/data_handler/data_processors.py
+++ b/qualang_tools/results/data_handler/data_processors.py
@@ -187,7 +187,7 @@ class XarraySaver(DataProcessor):
 
 
 try:
-    import xarray
+    import xarray  # noqa: F401
 
     DEFAULT_DATA_PROCESSORS.append(XarraySaver)
 except ImportError:

--- a/qualang_tools/results/data_handler/data_processors.py
+++ b/qualang_tools/results/data_handler/data_processors.py
@@ -186,4 +186,9 @@ class XarraySaver(DataProcessor):
                 array.to_netcdf(data_folder / path.with_suffix(self.file_suffix))
 
 
-DEFAULT_DATA_PROCESSORS.append(XarraySaver)
+try:
+    import xarray
+
+    DEFAULT_DATA_PROCESSORS.append(XarraySaver)
+except ImportError:
+    pass


### PR DESCRIPTION
The Xarray data processor was added as a default data processor for the data handler. This raises an error if a save is performed and xarray isn't installed.

The data processor is now only added by default if xarray is installed