### PR TITLE
Fix init of ManualOutputControl (remove old logger call)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
-
+- Fix init of ManualOutputControl (remove old logger call).
 ## [0.17.3] - 2024-05-06
 ### Fixed
 - digital_filters - added `multi_exponential_decay` to `__init__` file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
-- Fix init of ManualOutputControl (remove old logger call).
+### Fixed
+- control_panel - Fix init of ManualOutputControl (remove old logger call).
+
 ## [0.17.3] - 2024-05-06
 ### Fixed
 - digital_filters - added `multi_exponential_decay` to `__init__` file.

--- a/qualang_tools/control_panel/manual_output_control.py
+++ b/qualang_tools/control_panel/manual_output_control.py
@@ -42,7 +42,6 @@ class ManualOutputControl:
         :param array-like elements_to_control: A list of elements to be controlled.
                                     If empty, all elements in the config are included.
         """
-        logger.setLevel("WARNING")
         self.qmm = QuantumMachinesManager(host=host, port=port)
         if close_previous:
             self.qmm.close_all_quantum_machines()


### PR DESCRIPTION
When creating a `ManualOutputControl` object, `logger` doesn't exist because the export has been removed from `qm.qua`. I removed the call to the logger altogether.


Remember to:
* Update the CHANGELOG.md
* Added tests for the feature or fix --> The available test is not really a test, so I cannot update it.