### PR TITLE
Refactor: Move DEFAULT_DATA_PROCESSORS

### DIFF
--- a/qualang_tools/results/data_handler/__init__.py
+++ b/qualang_tools/results/data_handler/__init__.py
@@ -1,6 +1,23 @@
+from abc import ABC
+
 from .data_folder_tools import *
 from . import data_processors
-from .data_processors import DEFAULT_DATA_PROCESSORS
+
 from .data_handler import *
+
+
+DEFAULT_DATA_PROCESSORS = [
+    data_processors.MatplotlibPlotSaver,
+    data_processors.NumpyArraySaver,
+]
+
+
+try:
+    import xarray  # noqa: F401
+
+    DEFAULT_DATA_PROCESSORS.append(data_processors.XarraySaver)
+except ImportError:
+    pass
+
 
 __all__ = [*data_folder_tools.__all__, data_processors, DEFAULT_DATA_PROCESSORS, *data_handler.__all__]

--- a/qualang_tools/results/data_handler/data_processors.py
+++ b/qualang_tools/results/data_handler/data_processors.py
@@ -4,10 +4,7 @@ from typing import Dict, Any, Generator, List, Tuple, Optional
 from matplotlib import pyplot as plt
 import numpy as np
 
-__all__ = ["DEFAULT_DATA_PROCESSORS", "DataProcessor", "MatplotlibPlotSaver", "NumpyArraySaver", "XarraySaver"]
-
-
-DEFAULT_DATA_PROCESSORS = []
+__all__ = ["DataProcessor", "MatplotlibPlotSaver", "NumpyArraySaver", "XarraySaver"]
 
 
 def iterate_nested_dict(
@@ -78,9 +75,6 @@ class MatplotlibPlotSaver(DataProcessor):
             fig.savefig(data_folder / path)
 
 
-DEFAULT_DATA_PROCESSORS.append(MatplotlibPlotSaver)
-
-
 class NumpyArraySaver(DataProcessor):
     merge_arrays: bool = True
     merged_array_name: str = "arrays.npz"
@@ -116,9 +110,6 @@ class NumpyArraySaver(DataProcessor):
         else:
             for path, arr in self.data_arrays.items():
                 np.save(data_folder / path.with_suffix(".npy"), arr)
-
-
-DEFAULT_DATA_PROCESSORS.append(NumpyArraySaver)
 
 
 class XarraySaver(DataProcessor):
@@ -184,11 +175,3 @@ class XarraySaver(DataProcessor):
         else:
             for path, array in self.data_arrays.items():
                 array.to_netcdf(data_folder / path.with_suffix(self.file_suffix))
-
-
-try:
-    import xarray  # noqa: F401
-
-    DEFAULT_DATA_PROCESSORS.append(XarraySaver)
-except ImportError:
-    pass


### PR DESCRIPTION
Move `DEFAULT_DATA_PROCESSORS` from `data_processors.py` to `__init__.py`,

In response to comment by @yomach 