### PR TITLE
Added `volts2demod()` function to `units`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - octave_tools - Added the possibility to pass the AutoCalibrationParams to ``get_correction_for_each_LO_and_IF()`` to customize the calibration parameters (IF_amplitude for instance).
+- unit - ``volts2demod()`` function that does the inverse operation of ``demod2volts()``
 
 ## [0.17.4] - 2024-05-07
 ### Fixed

--- a/qualang_tools/units/units.py
+++ b/qualang_tools/units/units.py
@@ -202,6 +202,24 @@ class unit:
         else:
             return 4096 * data * self.V / duration
 
+    def volts2demod(
+        self,
+        value_in_volts: Union[float, ndarray],
+        duration: Union[float, int],
+        single_demod: bool = False,
+    ) -> Union[float, ndarray]:
+        """Converts the volts to demodulated data units.
+
+        :param value_in_volts: some value in volts. Must be a python variable or array.
+        :param duration: demodulation duration in ns.
+        :param single_demod: Flag to add the additional factor of 2 needed for single demod.
+        :return: the same value in demodulated data units.
+        """
+        if single_demod:
+            return (value_in_volts * duration) / (2 * 4096 * self.V)
+        else:
+            return (value_in_volts * duration) / (4096 * self.V)
+
     def raw2volts(self, data: Union[float, ndarray]) -> Union[float, ndarray]:
         """Converts the raw data to volts.
 


### PR DESCRIPTION
Similar to the inverse function `demod2volts()`.

This is useful in cases where a threshold value needs to be passed to the qua program in demodulated data units, but was found/calculated in volts.

- Updated in CHANGELOG.md

