### PR TITLE
Fix voltage book-keeping error introduced in #211

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Fixed
+- control_panel - Fix voltage booking error introduced in the previous fix.
 - control_panel - Fix rounding error in `ManualOutputControl` that caused voltage drifts.
 - octave_tools - Fix bug when setting calibrate to False in ``get_correction_for_each_LO_and_IF()``.
 - unit - ``to_clock_cycles()`` now always returns an integer.

--- a/qualang_tools/control_panel/manual_output_control.py
+++ b/qualang_tools/control_panel/manual_output_control.py
@@ -248,23 +248,21 @@ class ManualOutputControl:
 
         prev_value = self.analog_data[element]["amplitude"]
         if value != 0:
-            value = (value - prev_value) * (1 / self.ANALOG_WAVEFORM_AMPLITUDE)
-            value = _round_to_fixed_point_accuracy(value)
-            if value == 0:
+            delta_value = (value - prev_value) * (1 / self.ANALOG_WAVEFORM_AMPLITUDE)
+            delta_value = _round_to_fixed_point_accuracy(delta_value)
+            if delta_value == 0:
                 return
-            self.analog_data[element]["amplitude"] = _floor_to_fixed_point_accuracy(
-                prev_value + value * self.ANALOG_WAVEFORM_AMPLITUDE
-            )
+            set_value = _floor_to_fixed_point_accuracy(prev_value + delta_value * self.ANALOG_WAVEFORM_AMPLITUDE)
         else:
-            self.analog_data[element]["amplitude"] = 0.0
-
+            set_value = 0.0
+        self.analog_data[element]["amplitude"] = set_value
 
         while not self.analog_job.is_paused():
             sleep(0.01)
 
         self.analog_qm.set_io_values(
             int(self.analog_elements.index(element)) + len(self.analog_elements),
-            float(value),
+            float(set_value),
         )
         self.analog_job.resume()
 

--- a/qualang_tools/control_panel/manual_output_control.py
+++ b/qualang_tools/control_panel/manual_output_control.py
@@ -248,22 +248,23 @@ class ManualOutputControl:
 
         prev_value = self.analog_data[element]["amplitude"]
         if value != 0:
-            delta_value = (value - prev_value) * (1 / self.ANALOG_WAVEFORM_AMPLITUDE)
-            delta_value = _round_to_fixed_point_accuracy(delta_value)
-            if delta_value == 0:
+            value = (value - prev_value) * (1 / self.ANALOG_WAVEFORM_AMPLITUDE)
+            value = _round_to_fixed_point_accuracy(value)
+            if value == 0:
                 return
+            self.analog_data[element]["amplitude"] = _floor_to_fixed_point_accuracy(
+                prev_value + value * self.ANALOG_WAVEFORM_AMPLITUDE
+            )
         else:
-            delta_value = value
-        self.analog_data[element]["amplitude"] = _floor_to_fixed_point_accuracy(
-            prev_value + delta_value * self.ANALOG_WAVEFORM_AMPLITUDE
-        )
+            self.analog_data[element]["amplitude"] = 0.0
+
 
         while not self.analog_job.is_paused():
             sleep(0.01)
 
         self.analog_qm.set_io_values(
             int(self.analog_elements.index(element)) + len(self.analog_elements),
-            float(delta_value),
+            float(value),
         )
         self.analog_job.resume()
 


### PR DESCRIPTION
In #211 I introduced an error: when calling set_amplitude with value 0.0, the value on the OPX is correctly updated, but the record in the python program is not, breaking following updates.

Remember to:
- [x] Update the CHANGELOG.md
- ~~Added tests for the feature or fix~~