### PR TITLE
Bump version to 0.17.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+
+## [0.17.5] - 2024-06-26
 ### Fixed
 - control_panel - Fix voltage booking error introduced in the previous fix.
 - control_panel - Fix rounding error in `ManualOutputControl` that caused voltage drifts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qualang-tools"
-version = "v0.17.4"
+version = "v0.17.5"
 description = "The qualang_tools package includes various tools related to QUA programs in Python"
 license = "BSD-3-Clause"
 authors = [


### PR DESCRIPTION
## [0.17.5] - 2024-06-26
### Fixed
- control_panel - Fix voltage booking error introduced in the previous fix.
- control_panel - Fix rounding error in `ManualOutputControl` that caused voltage drifts.
- octave_tools - Fix bug when setting calibrate to False in ``get_correction_for_each_LO_and_IF()``.
- unit - ``to_clock_cycles()`` now always returns an integer.
- examples/Qcodes_drivers: Fixed compatibility with qm-qua 1.1.6 or newer.

### Added
- octave_tools - Added the possibility to pass the AutoCalibrationParams to ``get_correction_for_each_LO_and_IF()`` to customize the calibration parameters (IF_amplitude for instance).
- unit - ``volts2demod()`` function that does the inverse operation of ``demod2volts()``
- data_handler - Added support for nested figures and arrays

