### PR TITLE
Hotfix/fix figure saving in datahandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - results - Allow the data saver to create the root folder if it doesn't exist.
 
+### Fixed
+- data_handler - Fix figure saving cutting off title text if it is long using `bbox_inches="tight"`.
+
 ## [0.17.7] - 2024-08-20
 ### Added
 - VoltageGateSequence - The `VoltageGateSequence` class facilitates the creation and management of complex pulse sequences, allowing dynamic voltage control, ramping, and bias compensation across gate elements.

--- a/qualang_tools/results/data_handler/data_processors.py
+++ b/qualang_tools/results/data_handler/data_processors.py
@@ -106,7 +106,7 @@ class MatplotlibPlotSaver(DataProcessor):
 
     def post_process(self, data_folder: Path):
         for path, fig in self.data_figures.items():
-            fig.savefig(data_folder / path)
+            fig.savefig(data_folder / path, bbox_inches="tight")
 
 
 DEFAULT_DATA_PROCESSORS.append(MatplotlibPlotSaver)


### PR DESCRIPTION
Adds argument to `figure.savefig` call in the `DataHandler` to not cut off title text, etc.

Documentation from matplotlib:

> bbox_inches : str or [Bbox](https://matplotlib.org/3.1.1/api/transformations.html#matplotlib.transforms.Bbox), optional
>    Bbox in inches. Only the given portion of the figure is saved. If 'tight', try to figure out the tight bbox of the figure. If None, use savefig.bbox

### Before
```python
fig.savefig(data_folder / path)
```
![image](https://github.com/user-attachments/assets/6860e353-f55a-45b8-9aa3-4617b269349d)

### After
```python
fig.savefig(data_folder / path, bbox_inches="tight")
```
![image](https://github.com/user-attachments/assets/96b88737-c783-4726-8178-ac3e9b3bc749)

