### PR TITLE
Bump version to 0.17.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+
+## [0.17.8] - 2024-10-23
 ### Added
 - results - Allow the data saver to create the root folder if it doesn't exist.
 - wirer - Automatic tool to allocate channels for arbitrary combinations of QM instruments and superconducting qubits.
@@ -375,6 +377,7 @@ operation (readout pulse for instance) already defined in the configuration.
 - This release exposes the baking, RB and XEB functionality.
 
 [Unreleased]: https://github.com/qua-platform/py-qua-tools/compare/v0.17.7...HEAD
+[0.17.8]: https://github.com/qua-platform/py-qua-tools/compare/v0.17.7...v0.17.8
 [0.17.7]: https://github.com/qua-platform/py-qua-tools/compare/v0.17.6...v0.17.7
 [0.17.6]: https://github.com/qua-platform/py-qua-tools/compare/v0.17.5...v0.17.6
 [0.17.5]: https://github.com/qua-platform/py-qua-tools/compare/v0.17.4...v0.17.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qualang-tools"
-version = "v0.17.7"
+version = "v0.17.8"
 description = "The qualang_tools package includes various tools related to QUA programs in Python"
 authors = ["Quantum Machines <info@quantum-machines.co>"]
 license = "BSD-3-Clause"

--- a/qualang_tools/wirer/README.md
+++ b/qualang_tools/wirer/README.md
@@ -133,8 +133,8 @@ instruments.add_octave(indices=[1, 3, 8])
 ```
 ```python
 # Disjoint OPX+ and Octave addressing
-instruments.add_opx_plus(controllers=[2, 5])
-instruments.add_octave(indices=[1, 3, 8])
+instruments.add_lf_fem(controller=3, slots=[2, 4])
+instruments.add_mw_fem(controller=3, slots=[1, 7])
 ```
 
 ## Connectivity


### PR DESCRIPTION
# [0.17.8] - 2024-10-23
## Added
- results - Allow the data saver to create the root folder if it doesn't exist.
- wirer - Automatic tool to allocate channels for arbitrary combinations of QM instruments and superconducting qubits.
## Fixed
- data_handler - Fix figure saving cutting off title text if it is long using `bbox_inches="tight"`.
