### PR TITLE
 Bump version to 0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+
+## [0.18.1] - 2024-11-05
 ### Added
 - wirer - Support for fixed-frequency transmons, i.e., cross-resonant drive lines and zz drive lines
 
@@ -379,6 +381,7 @@ operation (readout pulse for instance) already defined in the configuration.
 - This release exposes the baking, RB and XEB functionality.
 
 [Unreleased]: https://github.com/qua-platform/py-qua-tools/compare/v0.17.7...HEAD
+[0.18.1]: https://github.com/qua-platform/py-qua-tools/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/qua-platform/py-qua-tools/compare/v0.17.7...v0.18.0
 [0.17.7]: https://github.com/qua-platform/py-qua-tools/compare/v0.17.6...v0.17.7
 [0.17.6]: https://github.com/qua-platform/py-qua-tools/compare/v0.17.5...v0.17.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qualang-tools"
-version = "v0.18.0"
+version = "v0.18.1"
 description = "The qualang_tools package includes various tools related to QUA programs in Python"
 authors = ["Quantum Machines <info@quantum-machines.co>"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
## [0.18.1] - 2024-11-05
### Added
- wirer - Support for fixed-frequency transmons, i.e., cross-resonant drive lines and zz drive lines
- examples/Qcodes_drivers: Added examples with the OPX1000.
- external_frameworks/qcodes - Added the `readout_sampling_rate` parameter for the OPX1000.

### Fixed
- external_frameworks/qcodes - Fixed the connection message and OPX identification to include the OPX1000 and QOP 2.4.
- voltage_gates - Fix the derivation of the compensation pulse for a small voltage*duration.

