### PR TITLE
Feat/voltagegates ramprate as a QUA variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - wirer - Support for fixed-frequency transmons, i.e., cross-resonant drive lines and zz drive lines
 - examples/Qcodes_drivers: Added examples with the OPX1000.
 - external_frameworks/qcodes - Added the `readout_sampling_rate` parameter for the OPX1000.
+- voltage_gates - Added the ability to set the ramp duration as a QUA variable.
 
 ### Fixed
 - external_frameworks/qcodes - Fixed the connection message and OPX identification to include the OPX1000 and QOP 2.4.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Octave tools Calibration Result Plotter
 - two-qubit rb - Added feature to plot the two qubit state distribution.
-
+- voltage_gates - Added the ability to set the ramp duration as a QUA variable.
+- 
 ### Fixed
 - two-qubit rb - Swapped the order of the circuit_depth and repeat axis for better performance.
 
@@ -46,7 +47,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - wirer - Support for fixed-frequency transmons, i.e., cross-resonant drive lines and zz drive lines
 - examples/Qcodes_drivers: Added examples with the OPX1000.
 - external_frameworks/qcodes - Added the `readout_sampling_rate` parameter for the OPX1000.
-- voltage_gates - Added the ability to set the ramp duration as a QUA variable.
 
 ### Fixed
 - external_frameworks/qcodes - Fixed the connection message and OPX identification to include the OPX1000 and QOP 2.4.

--- a/qualang_tools/voltage_gates/voltage_gate_sequence.py
+++ b/qualang_tools/voltage_gates/voltage_gate_sequence.py
@@ -3,7 +3,7 @@ import numpy as np
 from qm.qua import declare, assign, play, fixed, Cast, amp, wait, ramp, ramp_to_zero, Math
 from typing import Union, List, Dict
 from warnings import warn
-from qm.qua import QuaVariableType, QuaExpressionType
+from qm.qua._expressions import QuaExpression, QuaVariable
 
 
 class VoltageGateSequence:
@@ -72,7 +72,7 @@ class VoltageGateSequence:
 
     @staticmethod
     def _check_duration(duration: int):
-        if duration is not None and not isinstance(duration, (QuaVariableType, QuaExpressionType)):
+        if duration is not None and not isinstance(duration, (QuaExpression, QuaVariable)):
             if duration == 0:
                 warn(
                     "\nThe duration of one level is set to zero which can cause gaps, use with care or set it it to at least 16ns.",
@@ -114,14 +114,14 @@ class VoltageGateSequence:
 
     @staticmethod
     def is_QUA(var):
-        return isinstance(var, (QuaVariableType, QuaExpressionType))
+        return isinstance(var, (QuaExpression, QuaVariable))
 
     def add_step(
         self,
-        level: list[Union[float, QuaExpressionType, QuaVariableType]] = None,
-        duration: Union[int, QuaExpressionType, QuaVariableType] = None,
+        level: list[Union[float, QuaExpression, QuaVariable]] = None,
+        duration: Union[int, QuaExpression, QuaVariable] = None,
         voltage_point_name: str = None,
-        ramp_duration: Union[int, QuaExpressionType, QuaVariableType] = None,
+        ramp_duration: Union[int, QuaExpression, QuaVariable] = None,
     ) -> None:
         """Add a voltage level to the pulse sequence.
         The voltage level is either identified by its voltage_point_name if added to the voltage_point dict beforehand, or by its level and duration.
@@ -188,7 +188,7 @@ class VoltageGateSequence:
                             play(operation * amp((voltage_level - self.current_level[i]) * 4), gate)
 
                 # Fixed amplitude but dynamic duration --> new operation and play(duration=..)
-                elif isinstance(_duration, (QuaVariableType, QuaExpressionType)):
+                elif isinstance(_duration, (QuaExpression, QuaVariable)):
                     operation = self._add_op_to_config(
                         gate,
                         voltage_point_name,

--- a/qualang_tools/voltage_gates/voltage_gate_sequence.py
+++ b/qualang_tools/voltage_gates/voltage_gate_sequence.py
@@ -80,7 +80,7 @@ class VoltageGateSequence:
                 )
             else:
                 assert duration >= 4, "The duration must be a larger than 16 ns."
-                assert duration % 4 != 0, "The duration must be a multiple integer of 4ns."
+                assert duration % 4 == 0, "The duration must be a multiple integer of 4ns."
 
     def _update_averaged_power(self, level, duration, ramp_duration=None, current_level=None):
         if self.is_QUA(level):

--- a/qualang_tools/voltage_gates/voltage_gate_sequence.py
+++ b/qualang_tools/voltage_gates/voltage_gate_sequence.py
@@ -137,7 +137,7 @@ class VoltageGateSequence:
         if ramp_duration is not None:
             if self.is_QUA(ramp_duration):
                 warn(
-                    "\nYou are using a QUA variable for the ramp duration, make sure to stay at the final voltage level for more than 52ns otherwise you will have a gap or an error.",
+                    "\nYou are using a QUA variable for the ramp duration, make sure to stay at the final voltage level for more than 52ns or errors/gaps may occur, otherwise use a python variable.",
                     stacklevel=2,
                 )
 

--- a/qualang_tools/voltage_gates/voltage_gate_sequence.py
+++ b/qualang_tools/voltage_gates/voltage_gate_sequence.py
@@ -238,7 +238,7 @@ class VoltageGateSequence:
         self._check_duration(duration)
         for i, gate in enumerate(self._elements):
             if not self.is_QUA(self.average_power[i]):
-                compensation_amp = -0.001 * self.average_power[i] / duration
+                compensation_amp = -0.0009765625 * self.average_power[i] / duration
                 operation = self._add_op_to_config(
                     gate, "compensation", amplitude=compensation_amp - self.current_level[i], length=duration
                 )

--- a/qualang_tools/voltage_gates/voltage_gate_sequence.py
+++ b/qualang_tools/voltage_gates/voltage_gate_sequence.py
@@ -102,7 +102,7 @@ class VoltageGateSequence:
                     new_average += int(np.round(1024 * (level + current_level) * ramp_duration / 2))
 
             else:
-                new_average += Cast.mul_int_by_fixed(ramp_duration, (level + current_level) / 2)
+                new_average += Cast.mul_int_by_fixed(ramp_duration << 10, (level + current_level) / 2)
         return new_average
 
     @staticmethod

--- a/qualang_tools/voltage_gates/voltage_gate_sequence.py
+++ b/qualang_tools/voltage_gates/voltage_gate_sequence.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from qm.qua._dsl import QuaVariable, QuaExpression
 from qm.qua import declare, assign, play, fixed, Cast, amp, wait, ramp, ramp_to_zero, Math
 from typing import Union, List, Dict
 from warnings import warn
+from qm.qua import QuaVariableType, QuaExpressionType
 
 
 class VoltageGateSequence:
@@ -72,7 +72,7 @@ class VoltageGateSequence:
 
     @staticmethod
     def _check_duration(duration: int):
-        if duration is not None and not isinstance(duration, (QuaVariable, QuaExpression)):
+        if duration is not None and not isinstance(duration, (QuaVariableType, QuaExpressionType)):
             if duration == 0:
                 warn(
                     "\nThe duration of one level is set to zero which can cause gaps, use with care or set it it to at least 16ns.",
@@ -114,14 +114,14 @@ class VoltageGateSequence:
 
     @staticmethod
     def is_QUA(var):
-        return isinstance(var, (QuaVariable, QuaExpression))
+        return isinstance(var, (QuaVariableType, QuaExpressionType))
 
     def add_step(
         self,
-        level: list[Union[float, QuaExpression, QuaVariable]] = None,
-        duration: Union[int, QuaExpression, QuaVariable] = None,
+        level: list[Union[float, QuaExpressionType, QuaVariableType]] = None,
+        duration: Union[int, QuaExpressionType, QuaVariableType] = None,
         voltage_point_name: str = None,
-        ramp_duration: Union[int, QuaExpression, QuaVariable] = None,
+        ramp_duration: Union[int, QuaExpressionType, QuaVariableType] = None,
     ) -> None:
         """Add a voltage level to the pulse sequence.
         The voltage level is either identified by its voltage_point_name if added to the voltage_point dict beforehand, or by its level and duration.
@@ -188,7 +188,7 @@ class VoltageGateSequence:
                             play(operation * amp((voltage_level - self.current_level[i]) * 4), gate)
 
                 # Fixed amplitude but dynamic duration --> new operation and play(duration=..)
-                elif isinstance(_duration, (QuaVariable, QuaExpression)):
+                elif isinstance(_duration, (QuaVariableType, QuaExpressionType)):
                     operation = self._add_op_to_config(
                         gate,
                         voltage_point_name,

--- a/qualang_tools/voltage_gates/voltage_gate_sequence.py
+++ b/qualang_tools/voltage_gates/voltage_gate_sequence.py
@@ -128,7 +128,7 @@ class VoltageGateSequence:
         A ramp_duration can be used to ramp to the desired level instead of stepping to it.
 
         :param level: Desired voltage level of the different gates composing the virtual gate in Volt.
-        :param duration: How long the voltage level should be maintained in ns. Must be a multiple of 4ns and larger than 16ns.
+        :param duration: How long the voltage level should be maintained in ns. Must be a multiple of 4ns and either larger than 16ns or 0.
         :param voltage_point_name: Name of the voltage level if added to the list of relevant points in the charge stability map.
         :param ramp_duration: Duration in ns of the ramp if the voltage should be ramped to the desired level instead of stepped. Must be a multiple of 4ns and larger than 16ns.
         """
@@ -216,11 +216,9 @@ class VoltageGateSequence:
                 if not self.is_QUA(ramp_duration):
                     ramp_rate = 1 / ramp_duration
                     play(ramp((voltage_level - self.current_level[i]) * ramp_rate), gate, duration=ramp_duration >> 2)
-                    if not self.is_QUA(_duration):
-                        if _duration > 0:
-                            wait(_duration >> 2, gate)
-                    else:
+                    if self.is_QUA(_duration) or _duration > 0:
                         wait(_duration >> 2, gate)
+
                 else:
                     ramp_rate = declare(fixed)
                     assign(ramp_rate, (voltage_level - self.current_level[i]) * Math.div(1, ramp_duration))


### PR DESCRIPTION
Upon IBM's request, I adapted the class to allow the users to sweep the ramp rate in real time. I did basic testing using the simulator and everything seems to work and I added a warning, because the duration of the level after the ramp must be larger than 52ns because of a gap...