### PR TITLE
Add test for Wirer on fixed-frequency transmons for OPX+ and Octave.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+### Fixed
+ - wirer - Added test-case for OPX+ and Octave with fixed-frequency tranmsons.
 
 ## [0.18.1] - 2024-11-05
 ### Added

--- a/tests/wirer/test_wirer_cross_resonance.py
+++ b/tests/wirer/test_wirer_cross_resonance.py
@@ -3,7 +3,8 @@ import pytest
 from qualang_tools.wirer import *
 from qualang_tools.wirer.connectivity.element import QubitPairReference, QubitReference
 from qualang_tools.wirer.connectivity.wiring_spec import WiringLineType
-from qualang_tools.wirer.instruments.instrument_channel import InstrumentChannelMwFemOutput
+from qualang_tools.wirer.instruments.instrument_channel import InstrumentChannelMwFemOutput, InstrumentChannelOpxPlus, \
+    InstrumentChannelOpxPlusOutput, InstrumentChannelOctaveOutput
 
 visualize_flag = False
 
@@ -46,4 +47,53 @@ def test_2q_allocation_cross_resonance(instruments_2lf_2mw):
                         InstrumentChannelMwFemOutput(con=1, port=2, slot=3),
                         InstrumentChannelMwFemOutput(con=1, port=3, slot=3)
                     ][i]
+                )
+
+
+def test_2q_allocation_cross_resonance_opx_plus_octave(instruments_1opx_1octave):
+    qubits = [1, 2]
+    qubit_pairs = [(1, 2), (2, 1)]
+
+    connectivity = Connectivity()
+
+    connectivity.add_resonator_line(qubits=qubits)
+    allocate_wiring(connectivity, instruments_1opx_1octave)
+
+    connectivity.add_qubit_drive_lines(qubits=qubits)
+    allocate_wiring(connectivity, instruments_1opx_1octave, block_used_channels=False)
+
+    connectivity.add_qubit_pair_zz_drive_lines(qubit_pairs)
+    allocate_wiring(connectivity, instruments_1opx_1octave, block_used_channels=False)
+
+    connectivity.add_qubit_pair_cross_resonance_lines(qubit_pairs)
+    allocate_wiring(connectivity, instruments_1opx_1octave)
+
+    if visualize_flag:
+        visualize(connectivity.elements, instruments_1opx_1octave.available_channels)
+
+
+    for i, qubit_pair in enumerate(qubit_pairs):
+        xy_channels = connectivity.elements[QubitReference(qubit_pair[0])].channels[WiringLineType.DRIVE]
+        cr_channels = connectivity.elements[QubitPairReference(*qubit_pair)].channels[WiringLineType.CROSS_RESONANCE]
+        zz_channels = connectivity.elements[QubitPairReference(*qubit_pair)].channels[WiringLineType.ZZ_DRIVE]
+        assert len(xy_channels) == 3
+        assert len(cr_channels) == 3
+        assert len(zz_channels) == 3
+
+        # For each XY, XD and ZZ should be on the same channel for the same qubit pair + control index
+        for channels in [xy_channels, cr_channels, zz_channels]:
+            for j, channel in enumerate(channels):
+                assert pytest.channels_are_equal(
+                    channel, [
+                        [
+                            InstrumentChannelOpxPlusOutput(con=1, port=3),
+                            InstrumentChannelOpxPlusOutput(con=1, port=4),
+                            InstrumentChannelOctaveOutput(con=1, port=2),
+                        ],
+                        [
+                            InstrumentChannelOpxPlusOutput(con=1, port=5),
+                            InstrumentChannelOpxPlusOutput(con=1, port=6),
+                            InstrumentChannelOctaveOutput(con=1, port=3),
+                        ],
+                    ][i][j]
                 )

--- a/tests/wirer/test_wirer_cross_resonance.py
+++ b/tests/wirer/test_wirer_cross_resonance.py
@@ -6,7 +6,7 @@ from qualang_tools.wirer.connectivity.wiring_spec import WiringLineType
 from qualang_tools.wirer.instruments.instrument_channel import InstrumentChannelMwFemOutput, InstrumentChannelOpxPlus, \
     InstrumentChannelOpxPlusOutput, InstrumentChannelOctaveOutput
 
-visualize_flag = False
+visualize_flag = pytest.visualize_flag
 
 
 def test_2q_allocation_cross_resonance(instruments_2lf_2mw):


### PR DESCRIPTION
We noticed some strange allocation resulting on the OPX+ and Octave when using the wirer tool with fixed-frequency transmons, but after writing the test-case, it couldn't be reproduced.

Now after running:
```python
    qubits = [1, 2]
    qubit_pairs = [(1, 2), (2, 1)]

    connectivity = Connectivity()

    connectivity.add_resonator_line(qubits=qubits)
    allocate_wiring(connectivity, instruments_2lf_2mw)

    connectivity.add_qubit_drive_lines(qubits=qubits)
    allocate_wiring(connectivity, instruments_2lf_2mw, block_used_channels=False)

    connectivity.add_qubit_pair_zz_drive_lines(qubit_pairs)
    allocate_wiring(connectivity, instruments_2lf_2mw, block_used_channels=False)

    connectivity.add_qubit_pair_cross_resonance_lines(qubit_pairs)
    allocate_wiring(connectivity, instruments_2lf_2mw)
```

We get:
![image](https://github.com/user-attachments/assets/ecc259cf-437a-4a18-a786-bffa15d7e0d4)
![image](https://github.com/user-attachments/assets/171cf4ea-5b21-4583-85f2-684cbaea07db)
