### PR TITLE
Fix/allow drag with alpha equals 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - wirer - Added test-case for OPX+ and Octave with fixed-frequency tranmsons.
 - macros/long_wait - Fix issue with `threshold_for_looping` not enforced to be an integer.
 - simulator - Recast connection ports in `create_simulator_controller_connections` to be `int`, instead of `np.int64`.
+- config/waveform_tools - Allow to set the detuning of a DRAG waveform even when the alpha parameter is 0. 
+
+### Deprecated
+- config/waveform_tools - Remove the deprecated parameter `delta` that was replaced by `anharmonicity` for the DRAG waveforms.
 
 ## [0.18.2] - 2024-12-23
 ### Added

--- a/qualang_tools/config/waveform_tools.py
+++ b/qualang_tools/config/waveform_tools.py
@@ -40,6 +40,10 @@ def drag_gaussian_pulse_waveforms(
     if anharmonicity != detuning:
         # The complex DRAG envelope:
         z += 1j * gauss_der_wave * (alpha / (2 * np.pi * anharmonicity - 2 * np.pi * detuning))
+    elif alpha != 0:
+        raise ValueError(
+            "The complex envelop for the DRAG waveform cannot be created if anharmonicity = detuning and alpha != 0."
+        )
     # The complex detuned DRAG envelope:
     z *= np.exp(1j * 2 * np.pi * detuning * t * 1e-9)
     I_wf = z.real.tolist()  # The `I` component is the real part of the waveform
@@ -78,6 +82,10 @@ def drag_cosine_pulse_waveforms(amplitude, length, alpha, anharmonicity, detunin
     if anharmonicity != detuning:
         # The complex DRAG envelope:
         z += 1j * sin_wave * (alpha / (2 * np.pi * anharmonicity - 2 * np.pi * detuning))
+    elif alpha != 0:
+        raise ValueError(
+            "The complex envelop for the DRAG waveform cannot be created if anharmonicity = detuning and alpha != 0."
+        )
     # The complex detuned DRAG envelope:
     z *= np.exp(1j * 2 * np.pi * detuning * t * 1e-9)
     I_wf = z.real.tolist()  # The `I` component is the real part of the waveform

--- a/qualang_tools/config/waveform_tools.py
+++ b/qualang_tools/config/waveform_tools.py
@@ -26,46 +26,24 @@ def drag_gaussian_pulse_waveforms(
     :return: Returns a tuple of two lists. The first list is the 'I' waveform (real part) and the second is the
         'Q' waveform (imaginary part)
     """
-    delta = kwargs.get("delta", None)
-    if delta is not None:
-        print("'delta' has been replaced by 'anharmonicity' and will be deprecated in the future. ")
-        if alpha != 0 and delta == 0:
-            raise Exception("Cannot create a DRAG pulse with `anharmonicity=0`")
-        t = np.arange(length, step=1e9 / sampling_rate)  # An array of size pulse length in ns
-        center = (length - 1e9 / sampling_rate) / 2
-        gauss_wave = amplitude * np.exp(-((t - center) ** 2) / (2 * sigma**2))  # The gaussian function
-        gauss_der_wave = (
-            amplitude * (-2 * 1e9 * (t - center) / (2 * sigma**2)) * np.exp(-((t - center) ** 2) / (2 * sigma**2))
-        )  # The derivative of gaussian
-        if subtracted:
-            gauss_wave = gauss_wave - gauss_wave[-1]  # subtracted gaussian
-        z = gauss_wave + 1j * 0
-        if alpha != 0:
-            # The complex DRAG envelope:
-            z += 1j * gauss_der_wave * (alpha / (delta - 2 * np.pi * detuning))
-            # The complex detuned DRAG envelope:
-            z *= np.exp(1j * 2 * np.pi * detuning * t * 1e-9)
-        I_wf = z.real.tolist()  # The `I` component is the real part of the waveform
-        Q_wf = z.imag.tolist()  # The `Q` component is the imaginary part of the waveform
-    else:
-        if alpha != 0 and anharmonicity == 0:
-            raise Exception("Cannot create a DRAG pulse with `anharmonicity=0`")
-        t = np.arange(length, step=1e9 / sampling_rate)  # An array of size pulse length in ns
-        center = (length - 1e9 / sampling_rate) / 2
-        gauss_wave = amplitude * np.exp(-((t - center) ** 2) / (2 * sigma**2))  # The gaussian function
-        gauss_der_wave = (
-            amplitude * (-2 * 1e9 * (t - center) / (2 * sigma**2)) * np.exp(-((t - center) ** 2) / (2 * sigma**2))
-        )  # The derivative of gaussian
-        if subtracted:
-            gauss_wave = gauss_wave - gauss_wave[-1]  # subtracted gaussian
-        z = gauss_wave + 1j * 0
-        if alpha != 0:
-            # The complex DRAG envelope:
-            z += 1j * gauss_der_wave * (alpha / (2 * np.pi * anharmonicity - 2 * np.pi * detuning))
-            # The complex detuned DRAG envelope:
-            z *= np.exp(1j * 2 * np.pi * detuning * t * 1e-9)
-        I_wf = z.real.tolist()  # The `I` component is the real part of the waveform
-        Q_wf = z.imag.tolist()  # The `Q` component is the imaginary part of the waveform
+    if alpha != 0 and anharmonicity == 0:
+        raise Exception("Cannot create a DRAG pulse with `anharmonicity=0`")
+    t = np.arange(length, step=1e9 / sampling_rate)  # An array of size pulse length in ns
+    center = (length - 1e9 / sampling_rate) / 2
+    gauss_wave = amplitude * np.exp(-((t - center) ** 2) / (2 * sigma**2))  # The gaussian function
+    gauss_der_wave = (
+        amplitude * (-2 * 1e9 * (t - center) / (2 * sigma**2)) * np.exp(-((t - center) ** 2) / (2 * sigma**2))
+    )  # The derivative of gaussian
+    if subtracted:
+        gauss_wave = gauss_wave - gauss_wave[-1]  # subtracted gaussian
+    z = gauss_wave + 1j * 0
+    if alpha != 0:
+        # The complex DRAG envelope:
+        z += 1j * gauss_der_wave * (alpha / (2 * np.pi * anharmonicity - 2 * np.pi * detuning))
+        # The complex detuned DRAG envelope:
+        z *= np.exp(1j * 2 * np.pi * detuning * t * 1e-9)
+    I_wf = z.real.tolist()  # The `I` component is the real part of the waveform
+    Q_wf = z.imag.tolist()  # The `Q` component is the imaginary part of the waveform
     return I_wf, Q_wf
 
 
@@ -88,42 +66,22 @@ def drag_cosine_pulse_waveforms(amplitude, length, alpha, anharmonicity, detunin
     :return: Returns a tuple of two lists. The first list is the 'I' waveform (real part) and the second is the
         'Q' waveform (imaginary part)
     """
-    delta = kwargs.get("delta", None)
-    if delta is not None:
-        print("'delta' has been replaced by 'anharmonicity' and will be deprecated in the future.")
-        if alpha != 0 and anharmonicity == 0:
-            raise Exception("Cannot create a DRAG pulse with `anharmonicity=0`")
-        t = np.arange(length, step=1e9 / sampling_rate)  # An array of size pulse length in ns
-        end_point = length - 1e9 / sampling_rate
-        cos_wave = 0.5 * amplitude * (1 - np.cos(t * 2 * np.pi / end_point))  # The cosine function
-        sin_wave = (
-            0.5 * amplitude * (2 * np.pi / end_point * 1e9) * np.sin(t * 2 * np.pi / end_point)
-        )  # The derivative of cosine function
-        z = cos_wave + 1j * 0
-        if alpha != 0:
-            # The complex DRAG envelope:
-            z += 1j * sin_wave * (alpha / (delta - 2 * np.pi * detuning))
-            # The complex detuned DRAG envelope:
-            z *= np.exp(1j * 2 * np.pi * detuning * t * 1e-9)
-        I_wf = z.real.tolist()  # The `I` component is the real part of the waveform
-        Q_wf = z.imag.tolist()  # The `Q` component is the imaginary part of the waveform
-    else:
-        if alpha != 0 and anharmonicity == 0:
-            raise Exception("Cannot create a DRAG pulse with `anharmonicity=0`")
-        t = np.arange(length, step=1e9 / sampling_rate)  # An array of size pulse length in ns
-        end_point = length - 1e9 / sampling_rate
-        cos_wave = 0.5 * amplitude * (1 - np.cos(t * 2 * np.pi / end_point))  # The cosine function
-        sin_wave = (
-            0.5 * amplitude * (2 * np.pi / end_point * 1e9) * np.sin(t * 2 * np.pi / end_point)
-        )  # The derivative of cosine function
-        z = cos_wave + 1j * 0
-        if alpha != 0:
-            # The complex DRAG envelope:
-            z += 1j * sin_wave * (alpha / (2 * np.pi * anharmonicity - 2 * np.pi * detuning))
-            # The complex detuned DRAG envelope:
-            z *= np.exp(1j * 2 * np.pi * detuning * t * 1e-9)
-        I_wf = z.real.tolist()  # The `I` component is the real part of the waveform
-        Q_wf = z.imag.tolist()  # The `Q` component is the imaginary part of the waveform
+    if alpha != 0 and anharmonicity == 0:
+        raise Exception("Cannot create a DRAG pulse with `anharmonicity=0`")
+    t = np.arange(length, step=1e9 / sampling_rate)  # An array of size pulse length in ns
+    end_point = length - 1e9 / sampling_rate
+    cos_wave = 0.5 * amplitude * (1 - np.cos(t * 2 * np.pi / end_point))  # The cosine function
+    sin_wave = (
+        0.5 * amplitude * (2 * np.pi / end_point * 1e9) * np.sin(t * 2 * np.pi / end_point)
+    )  # The derivative of cosine function
+    z = cos_wave + 1j * 0
+    if alpha != 0:
+        # The complex DRAG envelope:
+        z += 1j * sin_wave * (alpha / (2 * np.pi * anharmonicity - 2 * np.pi * detuning))
+        # The complex detuned DRAG envelope:
+        z *= np.exp(1j * 2 * np.pi * detuning * t * 1e-9)
+    I_wf = z.real.tolist()  # The `I` component is the real part of the waveform
+    Q_wf = z.imag.tolist()  # The `Q` component is the imaginary part of the waveform
     return I_wf, Q_wf
 
 

--- a/qualang_tools/config/waveform_tools.py
+++ b/qualang_tools/config/waveform_tools.py
@@ -37,11 +37,11 @@ def drag_gaussian_pulse_waveforms(
     if subtracted:
         gauss_wave = gauss_wave - gauss_wave[-1]  # subtracted gaussian
     z = gauss_wave + 1j * 0
-    if alpha != 0:
+    if anharmonicity != detuning:
         # The complex DRAG envelope:
         z += 1j * gauss_der_wave * (alpha / (2 * np.pi * anharmonicity - 2 * np.pi * detuning))
-        # The complex detuned DRAG envelope:
-        z *= np.exp(1j * 2 * np.pi * detuning * t * 1e-9)
+    # The complex detuned DRAG envelope:
+    z *= np.exp(1j * 2 * np.pi * detuning * t * 1e-9)
     I_wf = z.real.tolist()  # The `I` component is the real part of the waveform
     Q_wf = z.imag.tolist()  # The `Q` component is the imaginary part of the waveform
     return I_wf, Q_wf
@@ -75,11 +75,11 @@ def drag_cosine_pulse_waveforms(amplitude, length, alpha, anharmonicity, detunin
         0.5 * amplitude * (2 * np.pi / end_point * 1e9) * np.sin(t * 2 * np.pi / end_point)
     )  # The derivative of cosine function
     z = cos_wave + 1j * 0
-    if alpha != 0:
+    if anharmonicity != detuning:
         # The complex DRAG envelope:
         z += 1j * sin_wave * (alpha / (2 * np.pi * anharmonicity - 2 * np.pi * detuning))
-        # The complex detuned DRAG envelope:
-        z *= np.exp(1j * 2 * np.pi * detuning * t * 1e-9)
+    # The complex detuned DRAG envelope:
+    z *= np.exp(1j * 2 * np.pi * detuning * t * 1e-9)
     I_wf = z.real.tolist()  # The `I` component is the real part of the waveform
     Q_wf = z.imag.tolist()  # The `Q` component is the imaginary part of the waveform
     return I_wf, Q_wf


### PR DESCRIPTION
- Remove deprecated `delta` parameter
- Allow to generate a DRAG waveform even if alpha=0 per Tom's request