### PR TITLE
Fix/recast `np.int64` to python `int` in `simulator.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - wirer - Added test-case for OPX+ and Octave with fixed-frequency tranmsons.
 - macros/long_wait - Fix issue with `threshold_for_looping` not enforced to be an integer.
+- simulator - Recast connection ports in `create_simulator_controller_connections` to be `int`, instead of `np.int64`.
 
 ## [0.18.2] - 2024-12-23
 ### Added

--- a/qualang_tools/simulator/simulator.py
+++ b/qualang_tools/simulator/simulator.py
@@ -33,11 +33,11 @@ def create_simulator_controller_connections(
                 first_con_port = np.nonzero(unused_connection[i, :])[0]
                 if first_con_port.size == 0:
                     break
-                first_con_port = first_con_port[0]
+                first_con_port = first_con_port[0].item()
                 second_con_port = np.nonzero(unused_connection[j, :])[0]
                 if second_con_port.size == 0:
                     break
-                second_con_port = second_con_port[0]
+                second_con_port = second_con_port[0].item()
                 if i + 1 in actual_controllers and j + 1 in actual_controllers:
                     controller_connections.append(
                         ControllerConnection(


### PR DESCRIPTION
# Recast `np.int64` to python `int` in `simulator.py`

I was using the `create_simulator_controller_connections` helper class to run a simulation with multiple controllers, but with the current version, there is a long error tree that I tracked back to have to do with passing `InterOpxChannel` a channel number that is `np.int64` type instead of `int`, as `protobuf` attempts to convert this number to bytes via `to_bytes`, which `int` has, but `np.int64` does not.

Here, I use the `item` method to copy the `np.int64` into a python `int`, which fixes the error. I've updated the changelog as well, I don't believe any new tests are required.

MWE:
```python
qmManager = QuantumMachinesManager(...)
simulate_config = SimulationConfig(
    duration=4000,
    controller_connections=create_simulator_controller_connections(2),
)
job = qmManager.simulate(config, prog, simulate_config)
```
Without the fix I proposed, this will give an `AttributeError`:
```python
File /opt/mambaforge/envs/opx-2.1/lib/python3.10/site-packages/betterproto/__init__.py:361, in dump_varint(value, stream)
    359     bits = value & 0x7F
    360     value >>= 7
--> 361 stream.write(bits.to_bytes(1, "little"))

AttributeError: 'numpy.int64' object has no attribute 'to_bytes'
```


