### PR TITLE
Bump version to 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+
+## [0.18.3] - 2025-02-07
 ### Added
 - characterization/two_qubit_rb - Migrate standard two-qubit randomized benchmarking implementation.
 
@@ -406,7 +408,8 @@ operation (readout pulse for instance) already defined in the configuration.
 ### Added
 - This release exposes the baking, RB and XEB functionality.
 
-[Unreleased]: https://github.com/qua-platform/py-qua-tools/compare/v0.18.2...HEAD
+[Unreleased]: https://github.com/qua-platform/py-qua-tools/compare/v0.19.0...HEAD
+[0.19.0]: https://github.com/qua-platform/py-qua-tools/compare/v0.18.2...v0.19.0
 [0.18.2]: https://github.com/qua-platform/py-qua-tools/compare/v0.18.1...v0.18.2
 [0.18.1]: https://github.com/qua-platform/py-qua-tools/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/qua-platform/py-qua-tools/compare/v0.17.7...v0.18.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
-## [0.18.3] - 2025-02-07
+## [0.19.0] - 2025-02-07
 ### Added
 - characterization/two_qubit_rb - Migrate standard two-qubit randomized benchmarking implementation.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qualang-tools"
-version = "v0.18.2"
+version = "v0.19.0"
 description = "The qualang_tools package includes various tools related to QUA programs in Python"
 authors = ["Quantum Machines <info@quantum-machines.co>"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
## [0.19.0] - 2025-02-07
### Added
- characterization/two_qubit_rb - Migrate standard two-qubit randomized benchmarking implementation.

### Fixed
- two_qubit_rb - Fixed bug in `unsafe` option to workaround firmware issue in QOP<3.3.0.
- wirer - Fixed bug in the visualizer for LF-FEM and MW-FEM.
- macros/long_wait - Fix issue with `threshold_for_looping` not enforced to be an integer.
- simulator - Recast connection ports in `create_simulator_controller_connections` to be `int`, instead of `np.int64`.
- config/waveform_tools - Allow to set the detuning of a DRAG waveform even when the alpha parameter is 0. 
- bakery - Fix error when waveform samples type was subclass of int/float (e.g. numpy.float64).

### Deprecated
- config/waveform_tools - Remove the deprecated parameter `delta` that was replaced by `anharmonicity` for the DRAG waveforms.
