### PR TITLE
Fix/2q rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+
+## [0.18.3] - 2025-02-07
 ### Added
 - characterization/two_qubit_rb - Migrate standard two-qubit randomized benchmarking implementation.
 
@@ -406,7 +408,8 @@ operation (readout pulse for instance) already defined in the configuration.
 ### Added
 - This release exposes the baking, RB and XEB functionality.
 
-[Unreleased]: https://github.com/qua-platform/py-qua-tools/compare/v0.18.2...HEAD
+[Unreleased]: https://github.com/qua-platform/py-qua-tools/compare/v0.19.0...HEAD
+[0.19.0]: https://github.com/qua-platform/py-qua-tools/compare/v0.18.2...v0.19.0
 [0.18.2]: https://github.com/qua-platform/py-qua-tools/compare/v0.18.1...v0.18.2
 [0.18.1]: https://github.com/qua-platform/py-qua-tools/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/qua-platform/py-qua-tools/compare/v0.17.7...v0.18.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
-## [0.18.3] - 2025-02-07
+## [0.19.0] - 2025-02-07
 ### Added
 - characterization/two_qubit_rb - Migrate standard two-qubit randomized benchmarking implementation.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qualang-tools"
-version = "v0.18.2"
+version = "v0.19.0"
 description = "The qualang_tools package includes various tools related to QUA programs in Python"
 authors = ["Quantum Machines <info@quantum-machines.co>"]
 license = "BSD-3-Clause"

--- a/qualang_tools/characterization/two_qubit_rb/__init__.py
+++ b/qualang_tools/characterization/two_qubit_rb/__init__.py
@@ -1,3 +1,4 @@
 from .two_qubit_rb import *
+from .two_qubit_rb.RBResult import RBResult
 
-__all__ = ["TwoQubitRb", "TwoQubitRbDebugger"]
+__all__ = ["TwoQubitRb", "TwoQubitRbDebugger", "RBResult"]

--- a/qualang_tools/characterization/two_qubit_rb/two_qubit_rb/RBResult.py
+++ b/qualang_tools/characterization/two_qubit_rb/two_qubit_rb/RBResult.py
@@ -27,10 +27,10 @@ class RBResult:
         Initializes the xarray Dataset to store the RB experiment data.
         """
         self.data = xr.Dataset(
-            data_vars={"state": (["circuit_depth", "repeat", "average"], self.state)},
+            data_vars={"state": (["repeat", "circuit_depth", "average"], self.state)},
             coords={
-                "circuit_depth": self.circuit_depths,
                 "repeat": range(self.num_repeats),
+                "circuit_depth": self.circuit_depths,
                 "average": range(self.num_averages),
             },
         )
@@ -64,24 +64,72 @@ class RBResult:
     def plot_with_fidelity(self):
         """
         Plots the RB fidelity as a function of circuit depth, including a fit to an exponential decay model.
-        The fitted curve is overlaid with the raw data points.
+        The fitted curve is overlaid with the raw data points, and error bars are included.
         """
         A, alpha, B = self.fit_exponential()
         fidelity = self.get_fidelity(alpha)
 
+        # Compute error bars
+        error_bars = (self.data == 0).mean(dim="average").std(dim="repeat").state.data
+
         plt.figure()
-        plt.plot(self.circuit_depths, self.get_decay_curve(), "o", label="Data")
-        plt.plot(
+        plt.errorbar(
             self.circuit_depths,
-            rb_decay_curve(np.array(self.circuit_depths), A, alpha, B),
-            "-",
-            label=f"Fidelity={fidelity * 100:.3f}%\nalpha={alpha:.4f}",
+            self.get_decay_curve(),
+            yerr=error_bars,
+            fmt=".",
+            capsize=2,
+            elinewidth=0.5,
+            color='blue',
+            label="Experimental Data",
         )
+
+        circuit_depths_smooth_axis = np.linspace(self.circuit_depths[0], self.circuit_depths[-1], 100)
+        plt.plot(
+            circuit_depths_smooth_axis,
+            rb_decay_curve(np.array(circuit_depths_smooth_axis), A, alpha, B),
+            color="red",
+            linestyle="--",
+            label=f"Exponential Fit"
+        )
+
+        plt.text(
+            0.5,
+            0.95,
+            f"2Q Clifford Fidelity = {fidelity * 100:.2f}%",
+            horizontalalignment="center",
+            verticalalignment="top",
+            fontdict={"fontsize": "large", "fontweight": "bold"},
+            transform=plt.gca().transAxes,
+        )
+
         plt.xlabel("Circuit Depth")
-        plt.ylabel("Fidelity")
-        plt.title("2Q Randomized Benchmarking Fidelity")
-        plt.legend()
+        plt.ylabel(fr"Probability to recover to $|00\rangle$")
+        plt.title("2Q Randomized Benchmarking")
+        plt.legend(framealpha=0)
         plt.show()
+
+
+    def plot_two_qubit_state_distribution(self):
+        """
+        Plot how the two-qubit state is distributed as a function of circuit-depth on average.
+        """
+        plt.plot(self.circuit_depths, (self.data.state == 0).mean(dim="average").mean(dim="repeat").data,
+                 label=r"$|00\rangle$", marker=".", color="c", linewidth=3)
+        plt.plot(self.circuit_depths, (self.data.state == 1).mean(dim="average").mean(dim="repeat").data,
+                 label=r"$|01\rangle$", marker=".", color="b", linewidth=1)
+        plt.plot(self.circuit_depths, (self.data.state == 2).mean(dim="average").mean(dim="repeat").data,
+                 label=r"$|10\rangle$", marker=".", color="y", linewidth=1)
+        plt.plot(self.circuit_depths, (self.data.state == 3).mean(dim="average").mean(dim="repeat").data,
+                 label=r"$|11\rangle$", marker=".", color="r", linewidth=1)
+        plt.axhline(0.25, color="grey", linestyle="--", linewidth=2, label="2Q mixed-state")
+
+        plt.xlabel("Circuit Depth")
+        plt.ylabel(fr"Probability to recover to a given state")
+        plt.title("2Q State Distribution vs. Circuit Depth")
+        plt.legend(framealpha=0, title="$2Q State $|q_cq_t\rangle$")
+        plt.show()
+
 
     def fit_exponential(self):
         """
@@ -95,7 +143,7 @@ class RBResult:
         """
         decay_curve = self.get_decay_curve()
 
-        popt, _ = curve_fit(rb_decay_curve, self.circuit_depths, decay_curve, p0=[0.75, -0.1, 0.25], maxfev=10000)
+        popt, _ = curve_fit(rb_decay_curve, self.circuit_depths, decay_curve, p0=[0.75, 0.9, 0.25], maxfev=10000)
         A, alpha, B = popt
 
         return A, alpha, B

--- a/qualang_tools/characterization/two_qubit_rb/two_qubit_rb/RBResult.py
+++ b/qualang_tools/characterization/two_qubit_rb/two_qubit_rb/RBResult.py
@@ -127,7 +127,8 @@ class RBResult:
         plt.xlabel("Circuit Depth")
         plt.ylabel(fr"Probability to recover to a given state")
         plt.title("2Q State Distribution vs. Circuit Depth")
-        plt.legend(framealpha=0, title="$2Q State $|q_cq_t\rangle$")
+        plt.legend(framealpha=0, title=r"2Q State $\mathbf{|q_cq_t\rangle}$",
+                   title_fontproperties={"weight": "bold"})
         plt.show()
 
 

--- a/qualang_tools/characterization/two_qubit_rb/two_qubit_rb_example.py
+++ b/qualang_tools/characterization/two_qubit_rb/two_qubit_rb_example.py
@@ -138,6 +138,9 @@ plt.show()
 res.plot_fidelity()
 plt.show()
 
+res.plot_two_qubit_state_distribution()
+plt.show()
+
 # verify/save the random sequences created during the experiment
 rb.save_sequences_to_file("sequences.txt")  # saves the gates used in each random sequence
 rb.save_command_mapping_to_file("commands.txt")  # saves mapping from "command id" to sequence


### PR DESCRIPTION
- Swap the order of the `circuit_depth` and `repeat` axes in both the QUA program and analysis, leading to more sensible results and reduced dependence on the circuit-depth density.
- Fixed the extraction of the fidelity by correcting the initial guess
- Improve the plotting of the decay curve by adding error bars at one-sigma
- Added feature to plot the state distribution as it evolves over circuit depth for debugging leakage.

![image](https://github.com/user-attachments/assets/4882812f-110f-48fe-9882-62bff29bbd31)
![image](https://github.com/user-attachments/assets/8dd7398d-0f49-4246-a286-cca357a6bffb)
