### PR TITLE
bump version v0.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+
+## [0.19.2] - 2025-03-05
 ### Added
 - Octave tools Calibration Result Plotter
 - two-qubit rb - Added feature to plot the two qubit state distribution.
@@ -429,7 +431,8 @@ operation (readout pulse for instance) already defined in the configuration.
 ### Added
 - This release exposes the baking, RB and XEB functionality.
 
-[Unreleased]: https://github.com/qua-platform/py-qua-tools/compare/v0.19.1...HEAD
+[Unreleased]: https://github.com/qua-platform/py-qua-tools/compare/v0.19.2...HEAD
+[0.19.2]: https://github.com/qua-platform/py-qua-tools/compare/v0.19.1...v0.19.2
 [0.19.1]: https://github.com/qua-platform/py-qua-tools/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/qua-platform/py-qua-tools/compare/v0.18.2...v0.19.0
 [0.18.2]: https://github.com/qua-platform/py-qua-tools/compare/v0.18.1...v0.18.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qualang-tools"
-version = "v0.19.1"
+version = "v0.19.2"
 description = "The qualang_tools package includes various tools related to QUA programs in Python"
 authors = ["Quantum Machines <info@quantum-machines.co>"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
## [0.19.2] - 2025-03-05
### Added
- Octave tools Calibration Result Plotter
- two-qubit rb - Added feature to plot the two qubit state distribution.
- voltage_gates - Added the ability to set the ramp duration as a QUA variable.
- voltage_gates - Added the automatic derivation of the compensation pulse duration based on a maximum allowed amplitude.

### Fixed
- octave_tools - Fixed broken API introduced with qm-qua 1.2.2
- octave_tools - Fixed bug in `set_correction_parameters_to_opx`.
- two-qubit rb - Swapped the order of the circuit_depth and repeat axis for better performance.

### Changed
- Updated matplotlib requirement to ^3.8.0 to support the Octave Tools Plotter