### PR TITLE
fix typo in octave_tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+### Fixed
+- octave_tools - Fixed typo in `get_calibration_parameters_from_db`.
 
 ## [0.19.2] - 2025-03-05
 ### Added

--- a/qualang_tools/octave_tools/octave_tools.py
+++ b/qualang_tools/octave_tools/octave_tools.py
@@ -49,9 +49,9 @@ def get_calibration_parameters_from_db(
         else:
             param["offsets"]["I"] = lo_cal.i0
         if hasattr(lo_cal, "get_q0"):
-            param["offsets"]["I"] = lo_cal.get_q0()
+            param["offsets"]["Q"] = lo_cal.get_q0()
         else:
-            param["offsets"]["I"] = lo_cal.q0
+            param["offsets"]["Q"] = lo_cal.q0
 
         if if_cal is not None:
             if hasattr(if_cal, "get_correction"):


### PR DESCRIPTION
octave_tools - Fixed typo in `get_calibration_parameters_from_db`.