### PR TITLE
Change: DataHandler save key 'parents' -> 'ancestors'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+### Changed
+- data_handler - Changed the `parents` key to `ancestors` for consistency with the timeline structure and qualibrate
+
 ### Fixed
 - octave_tools - Fixed typo in `get_calibration_parameters_from_db`.
 

--- a/qualang_tools/results/data_handler/data_handler.py
+++ b/qualang_tools/results/data_handler/data_handler.py
@@ -179,7 +179,7 @@ class DataHandler:
             "metadata": metadata,
             "data": self.node_data,  # TODO Add self.node_data
             "id": idx,
-            "parents": [idx - 1] if idx > 1 else [],
+            "ancestors": [idx - 1] if idx > 1 else [],
         }
 
     def create_data_folder(

--- a/tests/data_handler/test_data_handler.py
+++ b/tests/data_handler/test_data_handler.py
@@ -55,7 +55,7 @@ def test_data_handler_metadata(tmp_path):
         "metadata": {**metadata, "name": "my_data", "data_path": expected_data_folder},
         "id": 1,
         "data": {},
-        "parents": [],
+        "ancestors": [],
     }
     assert file_node == expected_file_node
 

--- a/tests/data_handler/test_data_handler_generate_node.py
+++ b/tests/data_handler/test_data_handler_generate_node.py
@@ -16,7 +16,7 @@ def test_generate_node_contents_empty_folder(tmp_path):
         "metadata": {"name": "msmt_name", "data_path": f"2023-02-01/#1_msmt_name_123456"},
         "data": {},
         "id": 1,
-        "parents": [],
+        "ancestors": [],
     }
 
 
@@ -32,7 +32,7 @@ def test_generate_node_contents_with_idx_and_created_at(tmp_path):
         "metadata": {"name": None, "data_path": f"2023-02-01/#{idx}_None_123456"},
         "data": {},
         "id": idx,
-        "parents": [1],
+        "ancestors": [1],
     }
 
 
@@ -49,7 +49,7 @@ def test_generate_node_contents_with_all_parameters(tmp_path):
         "metadata": {"name": None, "data_path": f"2023-02-01/#{idx}_None_123456", "key": "value"},
         "data": {},
         "id": idx,
-        "parents": [1],
+        "ancestors": [1],
     }
 
 
@@ -69,5 +69,5 @@ def test_generate_node_contents_with_existing_folder_properties(tmp_path):
         "metadata": {"name": "msmt_name", "data_path": f"2023-02-01/#2_msmt_name_123456"},
         "data": {},
         "id": 2,
-        "parents": [1],
+        "ancestors": [1],
     }


### PR DESCRIPTION
The datahandler adds a key called `parents` to `node.json`, which is a list containing one element (the previous idx). This was added so in the future we could allow for more complex timelines that include branches and merging.

However, it seems more appropriate to use the term `ancestors` for two reasons:
- In QUAlibrate, I want to reserve an additional keyword `parent` to indicate when a node is run as part of a graph. In this case, having both `parents` and `parent` can be confusing
- When talking about the timeline, it seems more natural to talk about ancestors and descendants

Technically speaking this is a breaking change, but I highly doubt anyone uses this so far