### PR TITLE
Bump version v0.19.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
-## [0.19.4] - 2025-04-11
+## [0.19.4] - 2025-04-30
 ### Added
 - Add support for WaveformReport in data handler
 - Documentation for the user-facing Wirer API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+
+## [0.19.4] - 2025-04-11
 ### Added
 - Add support for WaveformReport in data handler
 - Documentation for the user-facing Wirer API.
@@ -443,8 +445,9 @@ operation (readout pulse for instance) already defined in the configuration.
 ### Added
 - This release exposes the baking, RB and XEB functionality.
 
-[Unreleased]: https://github.com/qua-platform/py-qua-tools/compare/v0.19.3...HEAD
-[0.19.2]: https://github.com/qua-platform/py-qua-tools/compare/v0.19.2...v0.19.3
+[Unreleased]: https://github.com/qua-platform/py-qua-tools/compare/v0.19.4...HEAD
+[0.19.4]: https://github.com/qua-platform/py-qua-tools/compare/v0.19.3...v0.19.4
+[0.19.3]: https://github.com/qua-platform/py-qua-tools/compare/v0.19.2...v0.19.3
 [0.19.2]: https://github.com/qua-platform/py-qua-tools/compare/v0.19.1...v0.19.2
 [0.19.1]: https://github.com/qua-platform/py-qua-tools/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/qua-platform/py-qua-tools/compare/v0.18.2...v0.19.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - qm_session - Fixed type hint for output of context manager to correctly annotate the QuantumMachine.
 - qm_session - Fixed filtering to remove error message with qm-qua >= 1.2.0
-- callable_from_qua - Can now be used with the old API with deprecations.
+- callable_from_qua - Can now be used with the OPX1000.
 
 ## [0.19.3] - 2025-03-06
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qualang-tools"
-version = "v0.19.3"
+version = "v0.19.4"
 description = "The qualang_tools package includes various tools related to QUA programs in Python"
 authors = ["Quantum Machines <info@quantum-machines.co>"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
Needed for releasing the calibration graph:

## [0.19.4] - 2025-04-11
### Added
- Add support for WaveformReport in data handler

### Fixed
- qm_session - Fixed type hint for output of context manager to correctly annotate the QuantumMachine.
- qm_session - Fixed filtering to remove error message with qm-qua >= 1.2.0