### PR TITLE
Qua 1.2.4 compatibility

### DIFF
--- a/qualang_tools/callable_from_qua/_callable_from_qua.py
+++ b/qualang_tools/callable_from_qua/_callable_from_qua.py
@@ -8,7 +8,6 @@ from qm.program import Program
 from qm.qua import declare_stream, save, pause, align
 from qm.exceptions import QmQuaException
 from qm import QuantumMachine
-from qm.qua._dsl import _ResultSource
 from packaging.version import Version
 import qm
 
@@ -20,6 +19,13 @@ if Version(qm.__version__) < Version("1.2.2"):
     QuaVariable = _Variable
 else:
     from qm.qua.type_hints import QuaVariable
+
+# TODO: Remove this if block when we drop support for qm < 1.2.4 (and move the import that is currently in the
+#  else block to the top)
+if Version(qm.__version__) < Version("1.2.4"):
+    from qm.qua._dsl import _ResultSource as ResultStreamSource
+else:
+    from qm.qua.type_hints import ResultStreamSource
 
 
 __all__ = ["ProgramAddon", "callable_from_qua"]
@@ -46,27 +52,27 @@ def _get_program_scope():
 @dataclasses.dataclass
 class QuaCallableArgument:
     tag: str
-    stream: _ResultSource
+    stream: ResultStreamSource
 
 
 class QuaCallable:
     def __init__(
         self,
         fn: callable,
-        qua_callable_stream: _ResultSource,
+        qua_callable_stream: ResultStreamSource,
         qua_callable_id: int,
         args: List[Any],
         kwargs: Dict[str, Any],
     ):
         self._fn = fn
         self._qua_callable_id = qua_callable_id
-        self._streams: Dict[str, _ResultSource] = {}
+        self._streams: Dict[str, ResultStreamSource] = {}
         self._declare(qua_callable_stream, args, kwargs)
         self._last_arg_fetch: Dict[str, int] = {}
 
     def _declare(
         self,
-        qua_callable_stream: _ResultSource,
+        qua_callable_stream: ResultStreamSource,
         args: List[Any],
         kwargs: Dict[str, Any],
     ):

--- a/qualang_tools/callable_from_qua/_callable_from_qua.py
+++ b/qualang_tools/callable_from_qua/_callable_from_qua.py
@@ -16,6 +16,7 @@ import qm
 #  else block to the top)
 if Version(qm.__version__) < Version("1.2.2"):
     from qm.qua._dsl import _Variable
+
     QuaVariable = _Variable
 else:
     from qm.qua.type_hints import QuaVariable
@@ -30,6 +31,7 @@ else:
 
 __all__ = ["ProgramAddon", "callable_from_qua"]
 
+
 def _get_program_scope():
     # TODO: Remove this if block when we drop support for qm < 1.2.4 (and move the import that is currently in the
     #  else block to the top)
@@ -37,12 +39,14 @@ def _get_program_scope():
     if qua_below_1_2_4:
         try:
             from qm.qua._dsl import _get_root_program_scope
+
             return _get_root_program_scope()
         except IndexError:
             raise RuntimeError("Cannot get program scope. Please run this function inside a QUA program.")
     else:
         from qm.qua._scope_management.scopes_manager import scopes_manager
         from qm.qua import NoScopeFoundException
+
         try:
             return scopes_manager.program_scope
         except NoScopeFoundException:

--- a/qualang_tools/callable_from_qua/_callable_from_qua.py
+++ b/qualang_tools/callable_from_qua/_callable_from_qua.py
@@ -5,12 +5,42 @@ from typing import List, Any, Dict
 from functools import wraps
 from qm import QmJob
 from qm.program import Program
-from qm.qua import declare_stream, save, pause
+from qm.qua import declare_stream, save, pause, align
 from qm.exceptions import QmQuaException
 from qm import QuantumMachine
-from qm.qua._dsl import _ResultSource, _Variable, align, _get_root_program_scope
+from qm.qua._dsl import _ResultSource
+from packaging.version import Version
+import qm
+
+
+# TODO: Remove this if block when we drop support for qm < 1.2.2 (and move the import that is currently in the
+#  else block to the top)
+if Version(qm.__version__) < Version("1.2.2"):
+    from qm.qua._dsl import _Variable
+    QuaVariable = _Variable
+else:
+    from qm.qua.type_hints import QuaVariable
+
 
 __all__ = ["ProgramAddon", "callable_from_qua"]
+
+def _get_program_scope():
+    # TODO: Remove this if block when we drop support for qm < 1.2.4 (and move the import that is currently in the
+    #  else block to the top)
+    qua_below_1_2_4 = Version(qm.__version__) < Version("1.2.4")
+    if qua_below_1_2_4:
+        try:
+            from qm.qua._dsl import _get_root_program_scope
+            return _get_root_program_scope()
+        except IndexError:
+            raise RuntimeError("Cannot get program scope. Please run this function inside a QUA program.")
+    else:
+        from qm.qua._scope_management.scopes_manager import scopes_manager
+        from qm.qua import NoScopeFoundException
+        try:
+            return scopes_manager.program_scope
+        except NoScopeFoundException:
+            raise RuntimeError("Cannot get program scope. Please run this function inside a QUA program.")
 
 
 @dataclasses.dataclass
@@ -48,7 +78,7 @@ class QuaCallable:
         align()
 
     def _convert_to_qua_arg(self, arg_id: str, arg):
-        if isinstance(arg, _Variable):
+        if isinstance(arg, QuaVariable):
             tag = f"__qua_callable__{self._qua_callable_id}__{arg_id}"
             stream = declare_stream()
             save(arg, stream)
@@ -104,7 +134,7 @@ class QuaCallableEventManager(ProgramAddon):
 
         try:
             # Check if we are already inside a program
-            _get_root_program_scope()
+            _get_program_scope()
             self.declare_all()
         except QmQuaException:
             ...
@@ -175,7 +205,7 @@ def callable_from_qua(func: callable):
     @wraps(func)
     def wrapper(*args, **kwargs):
         try:
-            program = _get_root_program_scope()._program
+            program = _get_program_scope()._program
         except IndexError:
             return func(*args, **kwargs)
 

--- a/qualang_tools/callable_from_qua/_qua_patches.py
+++ b/qualang_tools/callable_from_qua/_qua_patches.py
@@ -10,12 +10,12 @@ from qm.simulate.interface import SimulationConfig
 import qm
 
 # TODO: Remove this if block when we drop support for qm < 1.2.4 (and keep only the import that is currently in the
-    #  else block)
-    qua_below_1_2_4 = Version(qm.__version__) < Version("1.2.4")
-    if qua_below_1_2_4:
-        from qm.qua._dsl import _ProgramScope as _ProgramScope_qua
-    else:
-        from qm.qua._scope_management._core_scopes import _ProgramScope as _ProgramScope_qua
+#  else block)
+qua_below_1_2_4 = Version(qm.__version__) < Version("1.2.4")
+if qua_below_1_2_4:
+    from qm.qua._dsl import _ProgramScope as _ProgramScope_qua
+else:
+    from qm.qua._scope_management._core_scopes import _ProgramScope as _ProgramScope_qua
 
 __all__ = [
     "patch_qua_program_addons",
@@ -114,22 +114,22 @@ def patch_qua_program_addons():
 
         Program.addons: Dict[str, ProgramAddon] = {}
 
-
     # TODO: Remove this if block when we drop support for qm < 1.2.4 (and keep only the import that is currently in the
     #  else block)
     if qua_below_1_2_4:
         import qm.qua._dsl
+
         if qm.qua._dsl._ProgramScope is _ProgramScope:
             print("qm.qua._dsl._ProgramScope already patched, not patching")
         else:
             qm.qua._dsl._ProgramScope = _ProgramScope
     else:
         import qm.qua._scope_management._core_scopes
+
         if qm.qua._scope_management._core_scopes._ProgramScope is _ProgramScope:
             print("qm.qua._dsl._ProgramScope already patched, not patching")
         else:
             qm.qua._scope_management._core_scopes._ProgramScope = _ProgramScope
-
 
     if qm.QuantumMachine.execute is QM_execute_patched:
         print("qm.QuantumMachine.QuantumMachine.execute already patched, not patching")

--- a/qualang_tools/loops/loops.py
+++ b/qualang_tools/loops/loops.py
@@ -18,7 +18,7 @@ def from_array(var, array):
 
     :param var: the QUA variable that will be looped over (int or fixed).
     :param array: a Python list or numpy array containing the values over which `a` will be looping. The spacing must be even in linear or logarithmic scales and it cannot be a QUA array.
-    :return: QUA for_ loop parameters (var, init, cond, update) as defined in https://qm-docs.qualang.io/api_references/qua/dsl_main?highlight=for_#qm.qua._dsl.for_.
+    :return: QUA for_ loop parameters (var, init, cond, update) as defined in https://qm-docs.qualang.io/api_references/qua/dsl_main?highlight=for_#qm.qua.for_.
     """
 
     # Check for array length
@@ -142,7 +142,7 @@ def qua_arange(var, start, stop, step):
     :param start: Start of interval. The interval includes this value. Must be a Python variable.
     :param stop: End of interval. The interval does not include this value. Must be a Python variable.
     :param step: Spacing between values. Must be a Python variable.
-    :return: QUA for_ loop parameters (var, init, cond, update) as defined in https://qm-docs.qualang.io/api_references/qua/dsl_main?highlight=for_#qm.qua._dsl.for_.
+    :return: QUA for_ loop parameters (var, init, cond, update) as defined in https://qm-docs.qualang.io/api_references/qua/dsl_main?highlight=for_#qm.qua.for_.
     """
     # Check QUA vs python variables
     if not isinstance(var, Variable):
@@ -183,7 +183,7 @@ def qua_linspace(var, start, stop, num):
     :param start: The starting value of the sequence. The interval includes this value. Must be a Python variable.
     :param stop: The end value of the sequence. The interval includes this value within the 2**-28 fixed point accuracy. Must be a Python variable.
     :param num: Number of samples to generate. Must be a Python variable.
-    :return: QUA for_ loop parameters (var, init, cond, update) as defined in https://qm-docs.qualang.io/api_references/qua/dsl_main?highlight=for_#qm.qua._dsl.for_.
+    :return: QUA for_ loop parameters (var, init, cond, update) as defined in https://qm-docs.qualang.io/api_references/qua/dsl_main?highlight=for_#qm.qua.for_.
     """
     # Check QUA vs python variables
     if not isinstance(var, Variable):
@@ -224,7 +224,7 @@ def qua_logspace(var, start, stop, num):
     :param start: The starting value of the sequence as 10**start in linear space. The interval includes this value. Must be a Python variable.
     :param stop: The end value of the sequence as 10**stop in linear space. The interval includes this value within the 2**-28 fixed point accuracy. Must be a Python variable.
     :param num: Number of samples to generate. Must be a Python variable.
-    :return: QUA for_ loop parameters (var, init, cond, update) as defined in https://qm-docs.qualang.io/api_references/qua/dsl_main?highlight=for_#qm.qua._dsl.for_.
+    :return: QUA for_ loop parameters (var, init, cond, update) as defined in https://qm-docs.qualang.io/api_references/qua/dsl_main?highlight=for_#qm.qua.for_.
     """
     # Check QUA vs python variables
     if not isinstance(var, Variable):


### PR DESCRIPTION
This PR updates several imports from the internal path qm.qua._dsl, which were never officially supported and will stop working in the next version of the qm-qua SDK. It ensures compatibility with version 1.2.4 while preserving backwards compatibility with older versions.
I tested with an older version to verify that nothing breaks, although I'm not familiar with the test structure or whether the files I modified are actually covered by the tests.
