### PR TITLE
Control Panel compatibility updates for `qm.qua >= 1.2.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+- control_panel - Fix call to `qmm.version` that had changed in qm.qua >= 1.2.1.
+- control_panel - Remove `qmm.close` call, after it was deprecated in qm.qua >= 1.2.1.
 
 ## [0.19.5] - 2025-05-30
 ### Added

--- a/qualang_tools/control_panel/manual_output_control.py
+++ b/qualang_tools/control_panel/manual_output_control.py
@@ -394,7 +394,6 @@ class ManualOutputControl:
                     qm.close()
         self.analog_job.halt()
         self.analog_qm.close()
-        self.qmm.close()
 
     def _process_config(self, config_original, elements_to_control=None):
         """
@@ -532,7 +531,7 @@ class ManualOutputControl:
                 "frequency": self.analog_config["elements"][element].get("intermediate_frequency"),
             }
 
-        opx_plus = True if self.qmm.version()["server"][0] == "2" else False
+        opx_plus = True if self.qmm.version_dict()["server"][0] == "2" else False
         for con in list(config["controllers"].keys()):
             if opx_plus and pulser_count[con] > 18:
                 raise Exception(


### PR DESCRIPTION
This pull request includes updates to ensure compatibility with the latest version of `qm.qua` (>= 1.2.1) by fixing deprecated calls and modifying method implementations. The changes involve updating the `qmm.version` call, and removing the deprecated `qmm.close` call.

