### PR TITLE
Bump version 0.19.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
-## [0.19.6] - 2025-08-04
+## [0.20.0] - 2025-08-04
 ### Changed
 - **Breaking change!** - callable_from_qua is not working for qm-qua <= 1.2.0
 - requirements - Change qm-qua requirement to >=1.2.2
@@ -471,8 +471,8 @@ operation (readout pulse for instance) already defined in the configuration.
 ### Added
 - This release exposes the baking, RB and XEB functionality.
 
-[Unreleased]: https://github.com/qua-platform/py-qua-tools/compare/v0.19.6...HEAD
-[0.19.6]: https://github.com/qua-platform/py-qua-tools/compare/v0.19.5...v0.19.6
+[Unreleased]: https://github.com/qua-platform/py-qua-tools/compare/v0.20.0...HEAD
+[0.20.0]: https://github.com/qua-platform/py-qua-tools/compare/v0.19.5...v0.20.0
 [0.19.5]: https://github.com/qua-platform/py-qua-tools/compare/v0.19.4...v0.19.5
 [0.19.4]: https://github.com/qua-platform/py-qua-tools/compare/v0.19.3...v0.19.4
 [0.19.3]: https://github.com/qua-platform/py-qua-tools/compare/v0.19.2...v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qualang-tools"
-version = "v0.19.6"
+version = "v0.20.0"
 description = "The qualang_tools package includes various tools related to QUA programs in Python"
 authors = ["Quantum Machines <info@quantum-machines.co>"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
### Changed
- **Breaking change!** - callable_from_qua is not working for qm-qua <= 1.2.0
- requirements - Change qm-qua requirement to >=1.2.2

### Added
- wirer - Web-based visualization for compact, stacked instrument configuration viewing.

### Fixed
- voltage_gates - Improve compensation pulse generation and allow playing ramps in amplified mode.
- control_panel - Fix call to `qmm.version` that had changed in qm.qua >= 1.2.1.

### Removed
- control_panel - Remove `qmm.close` call, after it was deprecated in qm.qua >= 1.2.1.