### PR TITLE
corrected unit error in ramp_to_zero example

### DIFF
--- a/qualang_tools/voltage_gates/README.md
+++ b/qualang_tools/voltage_gates/README.md
@@ -138,7 +138,7 @@ def ramp_to_zero(self, duration: int = None):
 **Example Usage**:
 
 ```python
-# Ramp all gate voltages down to zero over 500 ns
+# Ramp all gate voltages down to zero over 500 clock cycles
 seq.ramp_to_zero(duration=500)
 ```
 


### PR DESCRIPTION
Corrected example for `ramp_to_zero`. Changed text to indicate that the duration was 500 clock cycles rather than 500 ns.