### PR TITLE
Wirer update for digital channels

### DIFF
--- a/qualang_tools/wirer/connectivity/connectivity_transmon_interface.py
+++ b/qualang_tools/wirer/connectivity/connectivity_transmon_interface.py
@@ -142,7 +142,9 @@ class Connectivity(ConnectivityBase):
             WiringFrequency.DC, WiringIOType.OUTPUT, WiringLineType.FLUX, triggered, constraints, elements
         )
 
-    def add_qubit_pair_flux_lines(self, qubit_pairs: QubitPairsType, triggered: bool = False, constraints: ChannelSpec = None):
+    def add_qubit_pair_flux_lines(
+        self, qubit_pairs: QubitPairsType, triggered: bool = False, constraints: ChannelSpec = None
+    ):
         """
         Adds specifications (placeholders) for flux lines for a pair of qubits.
 

--- a/qualang_tools/wirer/connectivity/connectivity_transmon_interface.py
+++ b/qualang_tools/wirer/connectivity/connectivity_transmon_interface.py
@@ -97,7 +97,7 @@ class Connectivity(ConnectivityBase):
             WiringFrequency.RF, WiringIOType.OUTPUT, WiringLineType.DRIVE, triggered, constraints, elements
         )
 
-    def add_qubit_charge_lines(self, qubits: QubitsType, constraints: ChannelSpec = None):
+    def add_qubit_charge_lines(self, qubits: QubitsType, triggered: bool = False, constraints: ChannelSpec = None):
         """
         Adds specifications (placeholders) for charge lines for the specified qubits.
 
@@ -108,6 +108,7 @@ class Connectivity(ConnectivityBase):
 
         Args:
             qubits (QubitsType): The qubits to configure the charge lines for.
+            triggered (bool, optional): Whether the line is triggered. Defaults to False.
             constraints (ChannelSpec, optional): Constraints on the channel, if any. Defaults to None.
 
         Returns:
@@ -115,10 +116,10 @@ class Connectivity(ConnectivityBase):
         """
         elements = self._make_qubit_elements(qubits)
         return self.add_wiring_spec(
-            WiringFrequency.DC, WiringIOType.OUTPUT, WiringLineType.CHARGE, False, constraints, elements
+            WiringFrequency.DC, WiringIOType.OUTPUT, WiringLineType.CHARGE, triggered, constraints, elements
         )
 
-    def add_qubit_flux_lines(self, qubits: QubitsType, constraints: ChannelSpec = None):
+    def add_qubit_flux_lines(self, qubits: QubitsType, triggered: bool = False, constraints: ChannelSpec = None):
         """
         Adds specifications (placeholders) for flux bias lines for the specified qubits.
 
@@ -130,6 +131,7 @@ class Connectivity(ConnectivityBase):
 
         Args:
             qubits (QubitsType): The qubits to configure the flux bias lines for.
+            triggered (bool, optional): Whether the line is triggered. Defaults to False.
             constraints (ChannelSpec, optional): Constraints on the channel, if any. Defaults to None.
 
         Returns:
@@ -137,10 +139,10 @@ class Connectivity(ConnectivityBase):
         """
         elements = self._make_qubit_elements(qubits)
         return self.add_wiring_spec(
-            WiringFrequency.DC, WiringIOType.OUTPUT, WiringLineType.FLUX, False, constraints, elements
+            WiringFrequency.DC, WiringIOType.OUTPUT, WiringLineType.FLUX, triggered, constraints, elements
         )
 
-    def add_qubit_pair_flux_lines(self, qubit_pairs: QubitPairsType, constraints: ChannelSpec = None):
+    def add_qubit_pair_flux_lines(self, qubit_pairs: QubitPairsType, triggered: bool = False, constraints: ChannelSpec = None):
         """
         Adds specifications (placeholders) for flux lines for a pair of qubits.
 
@@ -152,6 +154,7 @@ class Connectivity(ConnectivityBase):
 
         Args:
             qubit_pairs (QubitPairsType): The qubit pairs to configure the flux lines for.
+            triggered (bool, optional): Whether the line is triggered. Defaults to False.
             constraints (ChannelSpec, optional): Constraints on the channel, if any. Defaults to None.
 
         Returns:
@@ -159,7 +162,7 @@ class Connectivity(ConnectivityBase):
         """
         elements = self._make_qubit_pair_elements(qubit_pairs)
         return self.add_wiring_spec(
-            WiringFrequency.DC, WiringIOType.OUTPUT, WiringLineType.COUPLER, False, constraints, elements
+            WiringFrequency.DC, WiringIOType.OUTPUT, WiringLineType.COUPLER, triggered, constraints, elements
         )
 
     def add_qubit_pair_cross_resonance_lines(

--- a/qualang_tools/wirer/connectivity/wiring_spec.py
+++ b/qualang_tools/wirer/connectivity/wiring_spec.py
@@ -11,10 +11,12 @@ if TYPE_CHECKING:
 class WiringFrequency(Enum):
     DC = "DC"
     RF = "RF"
+    DO = "DO"
 
 
 DC = WiringFrequency.DC
 RF = WiringFrequency.RF
+DO = WiringFrequency.DO
 
 
 class WiringIOType(Enum):

--- a/qualang_tools/wirer/wirer/channel_specs.py
+++ b/qualang_tools/wirer/wirer/channel_specs.py
@@ -516,3 +516,5 @@ opx_iq_ext_mixer_spec = ChannelSpecOpxPlusBasebandAndExternalMixer
 octave_spec = ChannelSpecOctave
 ext_mixer_spec = ChannelSpecExternalMixer
 opx_dig_spec = ChannelSpecOpxPlusDigital
+lf_fem_dig_spec = ChannelSpecLfFemDigital
+mw_fem_dig_spec = ChannelSpecMwFemDigital

--- a/qualang_tools/wirer/wirer/wirer.py
+++ b/qualang_tools/wirer/wirer/wirer.py
@@ -119,7 +119,12 @@ def allocate_dc_channels(spec: WiringSpec, instruments: Instruments):
     """
     Try to allocate DC channels to an LF-FEM or OPX+ to satisfy the spec.
     """
-    dc_specs = [ChannelSpecLfFemSingle(), ChannelSpecOpxPlusSingle()]
+    dc_specs = [
+        # LF-FEM, Single analog output
+        ChannelSpecLfFemSingle() & ChannelSpecLfFemDigital(),
+        # OPX+, Single analog output
+        ChannelSpecOpxPlusSingle() & ChannelSpecOpxPlusDigital()
+    ]
 
     allocate_channels(spec, dc_specs, instruments, same_con=True, same_slot=True)
 

--- a/qualang_tools/wirer/wirer/wirer.py
+++ b/qualang_tools/wirer/wirer/wirer.py
@@ -111,6 +111,9 @@ def _allocate_wiring(spec: WiringSpec, instruments: Instruments):
     elif spec.frequency == WiringFrequency.RF:
         allocate_rf_channels(spec, instruments)
 
+    elif spec.frequency == WiringFrequency.DO:
+        allocate_do_channels(spec, instruments)
+
     else:
         raise NotImplementedError()
 
@@ -156,6 +159,19 @@ def allocate_rf_channels(spec: WiringSpec, instruments: Instruments):
 
     allocate_channels(spec, rf_specs, instruments, same_con=True, same_slot=True)
 
+
+def allocate_do_channels(spec: WiringSpec, instruments: Instruments):
+    """
+    Try to allocate DC channels to an LF-FEM or OPX+ to satisfy the spec.
+    """
+    dc_specs = [
+        # LF-FEM, Single digital output
+        ChannelSpecLfFemDigital(),
+        # OPX+, Single digital output
+        ChannelSpecOpxPlusDigital()
+    ]
+
+    allocate_channels(spec, dc_specs, instruments, same_con=True, same_slot=True)
 
 def allocate_channels(
     wiring_spec: WiringSpec, channel_specs: List[ChannelSpec], instruments: Instruments, same_con: bool, same_slot: bool

--- a/qualang_tools/wirer/wirer/wirer.py
+++ b/qualang_tools/wirer/wirer/wirer.py
@@ -126,7 +126,7 @@ def allocate_dc_channels(spec: WiringSpec, instruments: Instruments):
         # LF-FEM, Single analog output
         ChannelSpecLfFemSingle() & ChannelSpecLfFemDigital(),
         # OPX+, Single analog output
-        ChannelSpecOpxPlusSingle() & ChannelSpecOpxPlusDigital()
+        ChannelSpecOpxPlusSingle() & ChannelSpecOpxPlusDigital(),
     ]
 
     allocate_channels(spec, dc_specs, instruments, same_con=True, same_slot=True)
@@ -168,10 +168,11 @@ def allocate_do_channels(spec: WiringSpec, instruments: Instruments):
         # LF-FEM, Single digital output
         ChannelSpecLfFemDigital(),
         # OPX+, Single digital output
-        ChannelSpecOpxPlusDigital()
+        ChannelSpecOpxPlusDigital(),
     ]
 
     allocate_channels(spec, dc_specs, instruments, same_con=True, same_slot=True)
+
 
 def allocate_channels(
     wiring_spec: WiringSpec, channel_specs: List[ChannelSpec], instruments: Instruments, same_con: bool, same_slot: bool

--- a/tests/wirer/test_wirer_digital.py
+++ b/tests/wirer/test_wirer_digital.py
@@ -5,7 +5,7 @@ import pytest
 from qualang_tools.wirer import *
 from qualang_tools.wirer.connectivity.element import QubitReference
 from qualang_tools.wirer.connectivity.wiring_spec import WiringLineType
-from qualang_tools.wirer.instruments.instrument_channel import InstrumentChannelMwFemDigitalOutput
+from qualang_tools.wirer.instruments.instrument_channel import InstrumentChannelMwFemDigitalOutput, InstrumentChannelLfFemDigitalOutput
 
 visualize_flag = pytest.visualize_flag
 
@@ -31,3 +31,53 @@ def test_triggered_wiring_spec_generates_digital_channels(instruments_2lf_2mw):
         resonator_channels_as_dicts = [asdict(channel) for channel in resonator_channels]
 
         assert asdict(InstrumentChannelMwFemDigitalOutput(con=1, port=1, slot=3)) in resonator_channels_as_dicts
+
+
+def test_triggered_wiring_spec_generates_digital_dc_channels(instruments_2lf_2mw):
+    connectivity = Connectivity()
+    qubits = [1, 2]
+    qubit_pairs = [(1, 2)]
+
+    connectivity.add_resonator_line(qubits=qubits)
+    connectivity.add_qubit_drive_lines(qubits=qubits)
+    connectivity.add_qubit_flux_lines(qubits=qubits, triggered=True)
+    connectivity.add_qubit_pair_flux_lines(qubit_pairs=qubit_pairs)
+
+    allocate_wiring(connectivity, instruments_2lf_2mw)
+
+    if visualize_flag:
+        visualize(connectivity.elements, instruments_2lf_2mw.available_channels)
+
+    # assert digital trigger channel is present
+    for qubit in [1, 2]:
+        flux_channels = connectivity.elements[QubitReference(index=qubit)].channels[WiringLineType.FLUX]
+        flux_channels_as_dicts = [asdict(channel) for channel in flux_channels]
+
+        assert asdict(InstrumentChannelLfFemDigitalOutput(con=1, port=qubit, slot=1)) in flux_channels_as_dicts
+
+
+def test_triggered_wiring_spec_generates_digital_only_channels(instruments_2lf_2mw):
+    connectivity = Connectivity()
+    qubits = [1, 2]
+    qubit_pairs = [(1, 2)]
+    def add_digital_only_element(self, qubits, triggered = False, constraints = None):
+        from qualang_tools.wirer.connectivity.wiring_spec import WiringFrequency, WiringIOType, WiringLineType
+        elements = self._make_qubit_elements(qubits)
+        return self.add_wiring_spec(WiringFrequency.DO, WiringIOType.OUTPUT, WiringLineType.FLUX, triggered, constraints, elements)
+
+    connectivity.add_resonator_line(qubits=qubits)
+    connectivity.add_qubit_drive_lines(qubits=qubits)
+    add_digital_only_element(connectivity, qubits=qubits, triggered=True)
+    connectivity.add_qubit_pair_flux_lines(qubit_pairs=qubit_pairs)
+
+    allocate_wiring(connectivity, instruments_2lf_2mw)
+
+    if visualize_flag:
+        visualize(connectivity.elements, instruments_2lf_2mw.available_channels)
+
+    # assert digital trigger channel is present
+    for qubit in [1, 2]:
+        flux_channels = connectivity.elements[QubitReference(index=qubit)].channels[WiringLineType.FLUX]
+        flux_channels_as_dicts = [asdict(channel) for channel in flux_channels]
+
+        assert asdict(InstrumentChannelLfFemDigitalOutput(con=1, port=qubit, slot=1)) in flux_channels_as_dicts


### PR DESCRIPTION
Add the possibility to attach a digital marker to a DC channel and to set up digital output only channels for triggering lasers for instance.
I also added the corresponding tests.