### PR TITLE
Bump version 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+
+## [0.21.0] - 2025-10-29
 ### Changed
 - **Breaking change!** requirements - Change qm-qua requirement to >=1.2.3
 
@@ -494,7 +496,8 @@ operation (readout pulse for instance) already defined in the configuration.
 ### Added
 - This release exposes the baking, RB and XEB functionality.
 
-[Unreleased]: https://github.com/qua-platform/py-qua-tools/compare/v0.20.1...HEAD
+[Unreleased]: https://github.com/qua-platform/py-qua-tools/compare/v0.21.0...HEAD
+[0.21.0]: https://github.com/qua-platform/py-qua-tools/compare/v0.20.1...v0.21.0
 [0.20.1]: https://github.com/qua-platform/py-qua-tools/compare/v0.20.0...v0.20.1
 [0.20.0]: https://github.com/qua-platform/py-qua-tools/compare/v0.19.5...v0.20.0
 [0.19.5]: https://github.com/qua-platform/py-qua-tools/compare/v0.19.4...v0.19.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qualang-tools"
-version = "v0.20.1"
+version = "v0.21.0"
 description = "The qualang_tools package includes various tools related to QUA programs in Python"
 authors = ["Quantum Machines <info@quantum-machines.co>"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
### Changed
- **Breaking change!** requirements - Change qm-qua requirement to >=1.2.3

### Added
- wirer - Add the possibility to restrict channels once the maximum number of pulsers per fem is reached.

### Fixed 
- data_handler - Fix deprecated import of `SimulatorControllerSamples`.
- callable_from_qua - Support for qm-qua >= 1.2.3.