### PR TITLE
Replace fetch_all with fetch_results

### DIFF
--- a/qualang_tools/results/results.py
+++ b/qualang_tools/results/results.py
@@ -28,13 +28,11 @@ class fetching_tool:
         self.data_list = data_list
         self.mode = mode
         self.results = []
-        self.data_handles = []
         self.res_handles = job.result_handles
         if mode == "live":
             for data in self.data_list:
                 if hasattr(self.res_handles, data):
-                    self.data_handles.append(self.res_handles.get(data))
-                    self.data_handles[-1].wait_for_values(1)
+                    self.res_handles.get(data).wait_for_values(1)
                 else:
                     raise Warning(f"{data} is not saved in the stream processing.")
             # Live plotting parameters


### PR DESCRIPTION
To implement the new `fetch_results` function in `qm-qua` > 1.2.3. I replace the `fetch_all` function.

After this change, I have run all the node in `~/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons` All programs test on opx+ and opx1000.