### PR TITLE
Bump version 0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+
+## [0.21.1] - 2026-01-16
 ### Fixed
 - connectivity - `WiringIOType.INPUT_AND_OUTPUT` of the SPCM component for the NV center.
 - qcodes OPX driver - Update to reflect changes in stream processing in qm-qua>=1.2.3
@@ -502,7 +504,8 @@ operation (readout pulse for instance) already defined in the configuration.
 ### Added
 - This release exposes the baking, RB and XEB functionality.
 
-[Unreleased]: https://github.com/qua-platform/py-qua-tools/compare/v0.21.0...HEAD
+[Unreleased]: https://github.com/qua-platform/py-qua-tools/compare/v0.21.1...HEAD
+[0.21.1]: https://github.com/qua-platform/py-qua-tools/compare/v0.21.0...v0.21.1
 [0.21.0]: https://github.com/qua-platform/py-qua-tools/compare/v0.20.1...v0.21.0
 [0.20.1]: https://github.com/qua-platform/py-qua-tools/compare/v0.20.0...v0.20.1
 [0.20.0]: https://github.com/qua-platform/py-qua-tools/compare/v0.19.5...v0.20.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qualang-tools"
-version = "v0.21.0"
+version = "v0.21.1"
 description = "The qualang_tools package includes various tools related to QUA programs in Python"
 authors = ["Quantum Machines <info@quantum-machines.co>"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
### Fixed
- connectivity - `WiringIOType.INPUT_AND_OUTPUT` of the SPCM component for the NV center.
- qcodes OPX driver - Update to reflect changes in stream processing in qm-qua>=1.2.3

### Change
- fetching_tool - Use `fetch_results` (>= 1.2.3) instead of `fetch_all`