### PR TITLE
Bump version v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+
+
+## [0.22.0] - 2026-04-01
 ### Added                                                                                                                                                                
 - wirer - Add wiring infrastructure for quantum-dot-based QPUs via the new `ConnectivityQuantumDotQubits` interface, including support for:                              
   - Plunger gate lines (`add_quantum_dot_voltage_gate_lines`)                                                                                                            
@@ -528,7 +531,8 @@ operation (readout pulse for instance) already defined in the configuration.
 ### Added
 - This release exposes the baking, RB and XEB functionality.
 
-[Unreleased]: https://github.com/qua-platform/py-qua-tools/compare/v0.21.1...HEAD
+[Unreleased]: https://github.com/qua-platform/py-qua-tools/compare/v0.22.0...HEAD
+[0.21.1]: https://github.com/qua-platform/py-qua-tools/compare/v0.21.1...v0.22.0
 [0.21.1]: https://github.com/qua-platform/py-qua-tools/compare/v0.21.0...v0.21.1
 [0.21.0]: https://github.com/qua-platform/py-qua-tools/compare/v0.20.1...v0.21.0
 [0.20.1]: https://github.com/qua-platform/py-qua-tools/compare/v0.20.0...v0.20.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qualang-tools"
-version = "v0.21.1"
+version = "v0.22.0"
 description = "The qualang_tools package includes various tools related to QUA programs in Python"
 authors = ["Quantum Machines <info@quantum-machines.co>"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
### Added                                                                                                                                                                
- wirer - Add wiring infrastructure for quantum-dot-based QPUs via the new `ConnectivityQuantumDotQubits` interface, including support for:                              
  - Plunger gate lines (`add_quantum_dot_voltage_gate_lines`)                                                                                                            
  - Barrier gate lines (`add_barrier_voltage_gate_lines` / `add_quantum_dot_pairs`)                                                                                    
  - Sensor dot voltage gate lines (`add_sensor_dot_voltage_gate_lines`)
  - Sensor dot resonator lines (`add_sensor_dot_resonator_line`)
  - RF drive lines for quantum dots (`add_quantum_dot_drive_lines`)
  - Convenience methods `add_quantum_dots`, `add_sensor_dots`, and `add_voltage_gate_lines`
- wirer - Add new `WiringLineType` entries: `PLUNGER_GATE`, `BARRIER_GATE`, `GLOBAL_GATE`, `SENSOR_GATE`, `RF_RESONATOR`
- wirer - Elements, qubits, and qubit pairs can now be identified by `str` as well as `int`
- wirer - Add TWPAs to the framework.

### Fixed
- multi_user_tool - Fix bug for qm-qua >= 1.2.3.
- wirer - Constrained wiring specs are now correctly prioritised during channel allocation

### Changed
- Changed Python version to `python<=3.13`.
- Changed numpy version to `numpy<3` to support numpy-2. Had to change optional cirq dependency to be
  `cirq==1.6.0` if `python>=3.11` else `cirq==1.5.0` if `python>=3.10,<3.11`
- voltage_gates - Voltages on all elements in a sequence are ramped to 0V with ramp_duration=16ns before calculating the compensation pulse. This behavior can be overridden by setting `start_at_zero=False` when calling `seq.add_compensation_pulse()`.
- voltage_gates - Voltages on all elements in a sequence are ramped to 0V with ramp_duration=16ns after applying the compensation pulse. This behavior can be overridden by setting `end_at_zero=False` when calling `seq.add_compensation_pulse()`.
