### PR TITLE
Remove deprecated 'version' key from QUA configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   - `set_closest_correction_parameters_to_opx` applies those parameters to a single element.
   - `apply_closest_calibrations` applies the closest calibration to all Octave elements in a config.
 
+### Fixed
+- config - Remove the deprecated `"version"` key from generated QUA configs (`ConfigBuilder`, `ManualOutputControl`, config-GUI upload template) to avoid the upstream `qm-qua` deprecation warning; the key will be removed entirely in `qm-qua` 2.0.0.
+
 
 ## [0.23.0] - 2026-07-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - config - Remove the deprecated `"version"` key from generated QUA configs (`ConfigBuilder`, `ManualOutputControl`, config-GUI upload template) to avoid the upstream `qm-qua` deprecation warning; the key will be removed entirely in `qm-qua` 2.0.0.
+- tests - Remove the deprecated `create_capabilities_container` test fixture call to avoid the upstream `qm-qua` deprecation warning; the function does nothing and will be removed in `qm-qua` 2.0.0.
 
 
 ## [0.23.0] - 2026-07-24

--- a/examples/Qcodes_drivers/advanced-driver/configuration.py
+++ b/examples/Qcodes_drivers/advanced-driver/configuration.py
@@ -1,5 +1,4 @@
 config = {
-    "version": 1,
     "controllers": {
         "con1": {
             "analog_outputs": {

--- a/examples/Qcodes_drivers/basic-driver/configuration.py
+++ b/examples/Qcodes_drivers/basic-driver/configuration.py
@@ -14,7 +14,6 @@ gate_1_amp = 0.25
 gate_2_amp = 0.25
 
 config = {
-    "version": 1,
     "controllers": {
         "con1": {
             "analog_outputs": {

--- a/examples/Qcodes_drivers/basic-driver/hello_qcodes_opx1000.py
+++ b/examples/Qcodes_drivers/basic-driver/hello_qcodes_opx1000.py
@@ -17,7 +17,6 @@ qop_port = None  # Write the QOP port if version < QOP220
 
 def get_config(fem = 3):
     config = {
-        "version": 1,
         "controllers": {
             "con1": {
                 "type": "opx1000",

--- a/examples/Qcodes_drivers/stability-diagram/configuration.py
+++ b/examples/Qcodes_drivers/stability-diagram/configuration.py
@@ -14,7 +14,6 @@ gate_1_amp = 0.25
 gate_2_amp = 0.25
 
 config = {
-    "version": 1,
     "controllers": {
         "con1": {
             "analog_outputs": {

--- a/examples/callable_from_qua/configuration.py
+++ b/examples/callable_from_qua/configuration.py
@@ -11,7 +11,6 @@ octave_config = None
 #                  Config                   #
 #############################################
 config = {
-    "version": 1,
     "controllers": {
         "con1": {
             "analog_outputs": {

--- a/examples/video_mode/configuration.py
+++ b/examples/video_mode/configuration.py
@@ -37,7 +37,6 @@ time_of_flight = 192
 
 
 config = {
-    "version": 1,
     "controllers": {
         "con1": {
             "analog_outputs": {

--- a/qualang_tools/config/configuration.py
+++ b/qualang_tools/config/configuration.py
@@ -19,16 +19,13 @@ from qualang_tools.config.primitive_components import (
 
 
 class QMConfiguration:
-    def __init__(self, controllers: List[Controller] = None, version: int = 1):
+    def __init__(self, controllers: List[Controller] = None):
         """A class to generate the QM configuration
 
         :param controllers: A controller or list of controllers used in this configuration, defaults to None
         :type controllers: List[Controller], optional
-        :param version: Controller version, defaults to 1
-        :type version: int, optional
         """
         self.config = dict()
-        self.config["version"] = 1
         self.config["controllers"] = dict()
         for cont in controllers:
             self.config["controllers"][cont.name] = self._call_dict_parameters(cont.dict)

--- a/qualang_tools/config/server/upload.py
+++ b/qualang_tools/config/server/upload.py
@@ -149,7 +149,6 @@ def init_empty_initial_config_file():
         fp.write(
             """
 configuration = {
-    "version": 1,
     "controllers": {},
     "elements": {},
     "pulses": {},

--- a/qualang_tools/control_panel/manual_output_control.py
+++ b/qualang_tools/control_panel/manual_output_control.py
@@ -92,7 +92,7 @@ class ManualOutputControl:
         """
         if analog_ports is None and digital_ports is None:
             raise Exception("No ports specified")
-        config = {"version": 1, "controllers": {}, "elements": {}}
+        config = {"controllers": {}, "elements": {}}
         if analog_ports is not None:
             for port_int in analog_ports:
                 if isinstance(port_int, tuple):
@@ -417,7 +417,6 @@ class ManualOutputControl:
         self.digital_qms = np.empty((highest_con, 10), dtype=QuantumMachine)
 
         # Analog config
-        self.analog_config["version"] = 1
         self.analog_config["controllers"] = {}
         for controller in list(config["controllers"].keys()):
             self.analog_config["controllers"][controller] = {
@@ -448,7 +447,6 @@ class ManualOutputControl:
             self.analog_config["mixers"] = config["mixers"]
 
         # Digital config
-        digital_config["version"] = 1
         digital_config["controllers"] = {}
         digital_config["elements"] = {}
         digital_config["pulses"] = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,7 @@
 import warnings
 from contextlib import contextmanager
 
-import pytest
-
-from qm.api.models.capabilities import QopCaps, ServerCapabilities
-from qm.api.models.info import QuaMachineInfo, ImplementationInfo
-from qm.containers.capabilities_container import create_capabilities_container
+from qm.api.models.capabilities import ServerCapabilities
 from qm import QuantumMachinesManager
 
 QuantumMachinesManager.set_capabilities_offline()
@@ -14,10 +10,3 @@ def ignore_deprecation_warnings():
     warnings.simplefilter("ignore")
     yield
     warnings.simplefilter("default")
-
-
-@pytest.fixture(autouse=True)
-def capability_container():
-    capabilities = QopCaps.get_all()
-    capabilities_qop_names = [cap.qop_name for cap in capabilities]
-    return create_capabilities_container(QuaMachineInfo(capabilities_qop_names, ImplementationInfo("", "", "")))

--- a/tests/test_bakery.py
+++ b/tests/test_bakery.py
@@ -30,7 +30,6 @@ def config():
         return [float(N * x) for x in [(1 - g) * c, (1 + g) * s, (1 - g) * s, (1 + g) * c]]
 
     return {
-        "version": 1,
         "controllers": {
             "con1": {
                 "type": "opx1",

--- a/tests/test_config_builder.py
+++ b/tests/test_config_builder.py
@@ -40,7 +40,6 @@ def config_resonator():
 def test_controller(config_resonator):
     config = config_resonator
     load_config(config)
-    assert config["version"] == 1
     assert "con1" in [*config["controllers"]]
     assert config["controllers"]["con1"]["type"] == "opx1"
     assert [*config["controllers"]["con1"]["analog_outputs"]] == [0, 1]

--- a/tests/test_config_gui.py
+++ b/tests/test_config_gui.py
@@ -28,5 +28,4 @@ def test_edit_file():
     importlib.reload(config_edits)
     importlib.reload(config_final)
     configuration = config_final.configuration
-    assert "version" in configuration
-    assert configuration["version"] >= 0
+    assert "controllers" in configuration

--- a/tests/test_config_helper_tools.py
+++ b/tests/test_config_helper_tools.py
@@ -14,7 +14,6 @@ def config0():
         return [float(N * x) for x in [(1 - g) * c, (1 + g) * s, (1 - g) * s, (1 + g) * c]]
 
     return {
-        "version": 1,
         "controllers": {
             "con1": {
                 "analog_outputs": {
@@ -119,7 +118,6 @@ def config0():
 @pytest.fixture
 def negative_delay_config():
     return {
-        "version": 1,
         "controllers": {
             "con1": {
                 "analog_outputs": {
@@ -209,7 +207,6 @@ def test_update_update_waveforms(config0):
 def test_transform_negative_delays(negative_delay_config):
     initial_config = deepcopy(negative_delay_config)
     corrected_config = {
-        "version": 1,
         "controllers": {
             "con1": {
                 "analog_outputs": {

--- a/tests/test_control_panel.py
+++ b/tests/test_control_panel.py
@@ -14,7 +14,6 @@ init_len = 9000
 readout_len = 10000
 
 config = {
-    "version": 1,
     "controllers": {
         "con1": {
             "type": "opx1",

--- a/tests/test_octave_tools.py
+++ b/tests/test_octave_tools.py
@@ -13,7 +13,6 @@ from qualang_tools.octave_tools import (
 @pytest.fixture
 def config():
     return {
-        "version": 1,
         "controllers": {
             "con1": {
                 "analog_outputs": {

--- a/tests/test_videomode.py
+++ b/tests/test_videomode.py
@@ -20,7 +20,6 @@ def config():
         return [float(N * x) for x in [(1 - g) * c, (1 + g) * s, (1 - g) * s, (1 + g) * c]]
 
     return {
-        "version": 1,
         "controllers": {
             "con1": {
                 "type": "opx1",

--- a/tests/tests_qua_utilities/conftest.py
+++ b/tests/tests_qua_utilities/conftest.py
@@ -25,7 +25,6 @@ FEM_IDX = 6
 ANALOG_OUTPUT_PORT = 8
 ANALOG_INPUT_PORT = 1
 config: FullQuaConfig = {
-    "version": 1,
     "controllers": {
         "con1": {
             "type": "opx1000",

--- a/tests/two_qubit_rb/conftest.py
+++ b/tests/two_qubit_rb/conftest.py
@@ -184,7 +184,6 @@ ge_threshold_q2 = 0.0
 @pytest.fixture
 def config() -> dict:
     config = {
-        "version": 1,
         "controllers": {
             "con1": {
                 "analog_outputs": {

--- a/tests_against_server/conftest.py
+++ b/tests_against_server/conftest.py
@@ -33,7 +33,6 @@ def qmm():
 def config():
 
     return {
-        "version": 1,
         "controllers": {
             "con1": {
                 "type": "opx1",

--- a/tests_against_server/test_bakery_server.py
+++ b/tests_against_server/test_bakery_server.py
@@ -29,7 +29,6 @@ def config():
         return [float(N * x) for x in [(1 - g) * c, (1 + g) * s, (1 - g) * s, (1 + g) * c]]
 
     return {
-        "version": 1,
         "controllers": {
             "con1": {
                 "type": "opx1000",

--- a/tests_against_server/test_digital_filters_server.py
+++ b/tests_against_server/test_digital_filters_server.py
@@ -200,7 +200,6 @@ ge_threshold = 0.0
 #                  Config                   #
 #############################################
 config = {
-    "version": 1,
     "controllers": {
         "con1": {
             "analog_outputs": {

--- a/tests_against_server/test_loops.py
+++ b/tests_against_server/test_loops.py
@@ -15,7 +15,6 @@ def config():
         return [float(N * x) for x in [(1 - g) * c, (1 + g) * s, (1 - g) * s, (1 + g) * c]]
 
     return {
-        "version": 1,
         "controllers": {
             "con1": {
                 "analog_outputs": {1: {"offset": 0.0}},

--- a/tests_against_server/test_multi_user.py
+++ b/tests_against_server/test_multi_user.py
@@ -15,7 +15,6 @@ def config1():
         return [float(N * x) for x in [(1 - g) * c, (1 + g) * s, (1 - g) * s, (1 + g) * c]]
 
     return {
-        "version": 1,
         "controllers": {
             "con1": {
                 "analog_outputs": {
@@ -124,7 +123,6 @@ def config2():
         return [float(N * x) for x in [(1 - g) * c, (1 + g) * s, (1 - g) * s, (1 + g) * c]]
 
     return {
-        "version": 1,
         "controllers": {
             "con1": {
                 "analog_outputs": {

--- a/tests_against_server/test_voltage_gate_sequence.py
+++ b/tests_against_server/test_voltage_gate_sequence.py
@@ -29,7 +29,6 @@ def config():
     hold_offset_duration = 4
 
     config = {
-        "version": 1,
         "controllers": {
             "con1": {
                 "analog_outputs": {

--- a/tests_against_server/voltage_gate_sequence/configuration.py
+++ b/tests_against_server/voltage_gate_sequence/configuration.py
@@ -88,7 +88,6 @@ pi_half_amps = [0.27, -0.27]
 #                  Config                   #
 #############################################
 config = {
-    "version": 1,
     "controllers": {
         "con1": {
             "analog_outputs": {

--- a/tests_against_server/voltage_gate_sequence/configuration_lf.py
+++ b/tests_against_server/voltage_gate_sequence/configuration_lf.py
@@ -114,7 +114,6 @@ pi_half_amps = [0.27, -0.27]
 #                  Config                   #
 #############################################
 config = {
-    "version": 1,
     "controllers": {
         con: {
             "type": "opx1000",


### PR DESCRIPTION
## Summary
- `qm-qua` warns whenever a QUA config dict contains a `"version"` key (deprecated since `1.2.2`, to be removed in `2.0.0`). `ConfigBuilder` (`QMConfiguration`), `ManualOutputControl`, and the config-GUI upload template all set this key unconditionally, so any user building a config through those paths hits the warning — not just the CI test that originally surfaced it.
- Removes the key from those library code paths, and from every test/example fixture that hardcoded it, so the warning can't resurface through a stale fixture.
- Drops the now fully unused `version` parameter from `QMConfiguration.__init__` — it had no callers anywhere in the repo and the old code already ignored whatever was passed, hardcoding `1` regardless.
- Adds a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `pytest tests/` (excluding `test_config_gui.py`, which needs the optional `dash`/`configbuilder` extra, and two pre-existing failures unrelated to this change: `test_config_builder.py::test_deprecated_warning` uses the removed `pytest.warns(None)` API, and `test_digital_filters.py` fails the same way before this change) — 463 passed, 0 warnings mentioning `'version'` or the Qua-config deprecation message.
- [x] Repo-wide `grep -rn '"version"'` confirms only the unrelated `config_structure["info"]["version"]` GUI-schema field remains.

Fixes the deprecation warning flagged by the `#sdk-deprecation-warnings` support-matrix bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)